### PR TITLE
Improved feedback when upgrade fails

### DIFF
--- a/src/docker.py
+++ b/src/docker.py
@@ -53,7 +53,12 @@ class Docker():
 
     def __extract_from_docker(self, docker_image: str, docker_binary_path: str, *args) -> None:
         docker_image_and_tag = f'{docker_image}:{self.docker_tag}'
-        sp.run(['docker', 'pull', docker_image_and_tag], check=True)
+
+        try:
+            sp.run(['docker', 'pull', docker_image_and_tag], stderr=sp.PIPE, check=True)
+        except sp.CalledProcessError as err:
+            raise ValueError(f"Could not pull {docker_image_and_tag} check 'docker-tag'!") from err
+
         sp.run(['docker', 'create', '--name', 'tmp', docker_image_and_tag], check=False)
         utils.stop_polkadot()
         sp.run(['docker', 'cp', f'tmp:{docker_binary_path}', utils.BINARY_PATH], check=True)

--- a/src/utils.py
+++ b/src/utils.py
@@ -45,6 +45,8 @@ def install_binary(config, chain_name):
 def install_binary_from_url(url, binary_check):
     # Download polkadot binary to memory and compute sha256 hash
     binary_response = requests.get(url, allow_redirects=True, timeout=None)
+    if binary_response.status_code != 200:
+        raise ValueError(f"Download binary failed with: {binary_response.text}. Check 'binary-url'!")
     if binary_check:
         binary_hash = hashlib.sha256(binary_response.content).hexdigest()
 


### PR DESCRIPTION
Sets status to Blocked and write the reason Message in juju status. E.g. for docker upgrades:
![image](https://github.com/dwellir-public/polkadot-operator/assets/5499769/b32f4eba-c43b-4ace-ac8e-aa1875eb84c6)
