### PR TITLE
Polkadot 1.1.0 adaptions - multiple binary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ With [Juju's OLM](https://juju.is/docs/olm) bootstrapping your cloud of choice, 
 However, there are some configs which are required by the charm to correctly install and start running the Polkadot client:
 
 - `binary-url=...` or `docker-tag=...`
+    - Note: from Polkadot release 1.1.0, the binary is split into three separate parts which means three separate URL:s will need to be set to the `binary-url` config, in a space separated list.
 - `service-args="... ..."` with the tags `--chain=...` and `--rpc-port=...` set
 
 With those configs included, a standard deployment of the Polkadot node could look like:

--- a/config.yaml
+++ b/config.yaml
@@ -8,10 +8,13 @@ options:
     description: |
       Path to download binary or .deb file from. E.g. https://github.com/paritytech/polkadot/releases/download/v0.9.10/polkadot
       Different installation methods will depending on if the file is a .deb or not.
-  binary-check:
-    type: boolean
-    default: true
-    description: "Downloads the sha256 of the binary and performs checksum check."
+  binary-sha256-url:
+    type: string
+    default: ""
+    description: |
+      If the URL is provided, the charm downloads the sha256 and performs a checksum check against the binary.
+
+      Note: needs to point to the sha256 corresponding to the 'binary-url' ahead of downloading the binary!
   docker-tag:
     type: string
     default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -6,15 +6,26 @@ options:
     type: string
     default: ""
     description: |
-      Path to download binary or .deb file from. E.g. https://github.com/paritytech/polkadot/releases/download/v0.9.10/polkadot
-      Different installation methods will depending on if the file is a .deb or not.
+      Path to download one or multiple binaries or a single .deb file.
+
+      Example 1: https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.1.0/polkadot-parachain
+
+      Example 2: "https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.1.0/polkadot https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.1.0/polkadot-execute-worker https://github.com/paritytech/polkadot-sdk/releases/download/polkadot-v1.1.0/polkadot-prepare-worker"
+
+      Example 3: https://github.com/ComposableFi/composable/releases/download/release-v9.10035.5/composable-node_8.10035.5-1_amd64.deb
+
+      Different installation methods will be used depending on if a .deb file is used or not.
+
+      Note: multiple binary install is currently only supported for Polkadot relay chains, parachain support is not confirmed.
   binary-sha256-url:
     type: string
     default: ""
     description: |
       If the URL is provided, the charm downloads the sha256 and performs a checksum check against the binary.
 
-      Note: needs to point to the sha256 corresponding to the 'binary-url' ahead of downloading the binary!
+      Note 1: needs to point to the sha256 corresponding to the 'binary-url' ahead of downloading the binary to actually perform the check!
+
+      Note 2: if multiple binary URL:s are supplied, multiple sha256 URL:s should be supplied as well, in the same order.
   docker-tag:
     type: string
     default: ""

--- a/src/utils.py
+++ b/src/utils.py
@@ -58,7 +58,7 @@ def install_binary(config: ConfigData, chain_name: str) -> None:
 
 def find_binary_installed_by_deb(package_name: str, ) -> str:
     files = sp.check_output(['dpkg', '-L', package_name]).decode().split('\n')[:-1]
-    bin_files = [file for file in files if file.startswith('/usr/bin/')]
+    bin_files = [file for file in files if file.startswith('/bin/')]
     logger.debug('Found files in /bin/ %s', str(bin_files))
     if len(bin_files) > 1:
         raise Exception(f'Found more than one file installed in /bin/ by package {package_name}. Cannot be sure which one to use.')

--- a/src/utils.py
+++ b/src/utils.py
@@ -107,6 +107,7 @@ def install_binaries_from_urls(binary_urls: str, sha256_urls: str) -> None:
     stop_polkadot()
     for binary_url, response in responses:
         logger.debug("Unpack binary downloaded from: %s", binary_url)
+        # TODO: keeping the binary name won't work for the charm if it's not exactly 'polkadot', adjust this if more chains start using multiple binaries
         with open(HOME_PATH / binary_url.split('/')[-1], 'wb') as f:
             f.write(response.content)
     start_polkadot()


### PR DESCRIPTION
- Makes the charm able to install multiple binaries, since that's now required (https://github.com/paritytech/polkadot-sdk/releases/tag/polkadot-v1.1.0). Does this by accepting a list of URL:s to the `binary-url` config, see examples in the code.
- Also updates `sha256` check to work with a list as well. New behavior will be that if no `binary-sha256-url` is supplied, no check will be made, e.g. we change from opt-in rather than opt-out as the default setting.

Note: a DEB package is also included in the latest Polkadot release, but me and @jonathanudd decided that handling those is a separate thing to pursue. Better to get support for multiple binaries merged quickly, and then look at what we want to do with DEB.

Thoughts?

Would be nice to merge a solution for the new Polkadot release ASAP, so we can start upgrading our nodes.