### PR TITLE
Update Canonical GitHub workflows version to v5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ on:
 jobs:
   build:
     name: Build nextcloud charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v2
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v5
 
   release:
     name: Release charm
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v2
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v5
     with:
       channel: latest/edge
       artifact-name: ${{ needs.build.outputs.artifact-name }}


### PR DESCRIPTION
`v5` listed as the latest tag here: https://github.com/canonical/data-platform-workflows/tags