### PR TITLE
Downgrade workflow to v4 due to error in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,13 @@ on:
 jobs:
   build:
     name: Build nextcloud charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v5
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v4
 
   release:
     name: Release charm
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v5
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v4
     with:
       channel: latest/edge
       artifact-name: ${{ needs.build.outputs.artifact-name }}


### PR DESCRIPTION
Reason: may solve issue in [Revision 11 release job](https://github.com/dwellir-public/polkadot-operator/actions/runs/6415769424)