### PR TITLE
Docs for charmhub.io

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,6 +16,7 @@ description: |
 website: https://dwellir.com
 source: https://github.com/dwellir-public/polkadot-operator
 issues: https://github.com/dwellir-public/polkadot-operator
+docs: https://discourse.charmhub.io/t/polkadot-docs-index/12391
 
 provides:
   node-prometheus:


### PR DESCRIPTION
Adds documentation to charmhub

https://juju.is/docs/sdk/add-docs-to-your-charmhub-page