### PR TITLE
Revision 14

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.autopep8"
+    },
+    "python.formatting.provider": "none"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "[python]": {
-        "editor.defaultFormatter": "ms-python.autopep8"
-    },
-    "python.formatting.provider": "none"
-}

--- a/README.md
+++ b/README.md
@@ -10,7 +10,37 @@ This repository is maintained by Dwellir, https://dwellir.com - Infrastructure p
 
 The charm starts the Polkadot client as a service, which takes its arguments from `/etc/default/polkadot` which in turn are set by the Juju config *service-args*. The Polkadot client itself is downloaded and installed from the config *binary-url*.
 
+## Building
+
+Though this charm is published on Charmhub there is also the alternative to build it locally, and to deploy it from that local build. It is built with the package charmcraft. See [charmcraft.yaml](charmcraft.yaml) for build details.
+
+    sudo snap install charmcraft --classic
+    charmcraft pack  # Assumes pwd is the polkadot-operator root directory
+
+## System requirements
+
+*Disclaimer: the system requriements to run a node in the Polkadot ecosystem varies, both depending on which chain is being run and which type of node it is. The example below should therefore be vetted against updated and reliable resources depending on your deployment specifications.*
+
+This list of reference hardware is from [the official Polkadot docs](https://wiki.polkadot.network/docs/maintain-guides-how-to-validate-polkadot) and is an example of good practice for a validator node:
+
+- CPU
+  - x86-64 compatible;
+  - Intel Ice Lake, or newer (Xeon or Core series); AMD Zen3, or newer (EPYC or Ryzen);
+  - 4 physical cores @ 3.4GHz;
+  - Simultaneous multithreading disabled (Hyper-Threading on Intel, SMT on AMD);
+  - Prefer single-threaded performance over higher cores count.
+- Storage
+  - An NVMe SSD of 1 TB (As it should be reasonably sized to deal with blockchain growth). An estimation of current chain snapshot sizes can be found [here](https://paranodes.io/DBSize). In general, the latency is more important than the throughput.
+- Memory
+  - 32 GB DDR4 ECC.
+- System
+  - Linux Kernel 5.16 or newer.
+- Network
+  - The minimum symmetric networking speed is set to 500 Mbit/s (= 62.5 MB/s). This is required to support a large number of parachains and allow for proper congestion control in busy network situations.
+
 ## Usage
+
+### Deploying Polkadot
 
 With [Juju's OLM](https://juju.is/docs/olm) bootstrapping your cloud of choice, and a Juju model created within that cloud to host the operator, the charm can be deployed as:
 
@@ -30,7 +60,7 @@ There are many more arguments available for the Polkadot client, which may or ma
 
     ./polkadot --help
 
-### Deploying other node types
+#### Deploying other node types
 
 There are a number of different node types in the Polkadot ecosystem, all which use the same client software to run. That means that by changing the client's service arguments in the deployment of this charm, one can easily change which node type to deploy. Read more about the specific node types on the Polkadot docs pages; [validator](https://wiki.polkadot.network/docs/learn-validator), [collator](https://wiki.polkadot.network/docs/learn-collator), [bootnode](https://wiki.polkadot.network/docs/maintain-bootnode), [RPC](https://wiki.polkadot.network/docs/maintain-rpc).
 
@@ -97,30 +127,9 @@ The `cos_agent` interface is already supported by this Polkadot operator charm s
 
 Find more details on how to deploy and use COS [here](https://charmhub.io/topics/canonical-observability-stack/tutorials/instrumenting-machine-charms).
 
-## Building
+## Resources
 
-Though this charm is published on Charmhub there is also the alternative to build it locally, and to deploy it from that local build. It is built with the package charmcraft. See [charmcraft.yaml](charmcraft.yaml) for build details.
-    
-    sudo snap install charmcraft --classic
-    charmcraft pack  # Assumes pwd is the polkadot-operator root directory
-
-## System requirements
-
-*Disclaimer: the system requriements to run a node in the Polkadot ecosystem varies, both depending on which chain is being run and which type of node it is. The example below should therefore be vetted against updated and reliable resources depending on your deployment specifications.*
-
-This list of reference hardware is from [the official Polkadot docs](https://wiki.polkadot.network/docs/maintain-guides-how-to-validate-polkadot) and is an example of good practice for a validator node:
-
-- CPU
-  - x86-64 compatible;
-  - Intel Ice Lake, or newer (Xeon or Core series); AMD Zen3, or newer (EPYC or Ryzen);
-  - 4 physical cores @ 3.4GHz;
-  - Simultaneous multithreading disabled (Hyper-Threading on Intel, SMT on AMD);
-  - Prefer single-threaded performance over higher cores count.
-- Storage
-  - An NVMe SSD of 1 TB (As it should be reasonably sized to deal with blockchain growth). An estimation of current chain snapshot sizes can be found [here](https://paranodes.io/DBSize). In general, the latency is more important than the throughput.
-- Memory
-  - 32 GB DDR4 ECC.
-- System
-  - Linux Kernel 5.16 or newer.
-- Network
-  - The minimum symmetric networking speed is set to 500 Mbit/s (= 62.5 MB/s). This is required to support a large number of parachains and allow for proper congestion control in busy network situations.
+- [Polkadot](https://polkadot.network/)
+- [Polkadot node on Charmhub](https://charmhub.io/polkadot)
+- [polkadot-operator repo on GitHub](https://github.com/dwellir-public/polkadot-operator)
+- [Dwellir](https://dwellir.com/)

--- a/actions.yaml
+++ b/actions.yaml
@@ -44,4 +44,10 @@ set-node-key:
   required: [ key ]
 
 get-node-info:
-  description: "Gets system information about the node for debugging purposes."
+  description: |
+    Gets system information about the node for debugging purposes.
+get-node-help:
+  description: |
+    Gets the help information from the client binary.
+    Note that to get a readable output it is recommended to use '--format json' and parse the output with the 'jq' command line etool.
+    Example: juju run-action --wait polkadot/0 get-node-help --format json | jq -r '.["unit-polkadot-0"].results["help-output"]'

--- a/actions.yaml
+++ b/actions.yaml
@@ -45,9 +45,9 @@ set-node-key:
 
 get-node-info:
   description: |
-    Gets system information about the node for debugging purposes.
+    Gets system information about the node and its container.
 get-node-help:
   description: |
     Gets the help information from the client binary.
-    Note that to get a readable output it is recommended to use '--format json' and parse the output with the 'jq' command line etool.
+    Note that to get a readable output it is recommended to use '--format json' and parse the output with the 'jq' command line tool.
     Example: juju run-action --wait polkadot/0 get-node-help --format json | jq -r '.["unit-polkadot-0"].results["help-output"]'

--- a/actions.yaml
+++ b/actions.yaml
@@ -27,6 +27,10 @@ insert-key:
 
 restart-node-service:
   description: "This actions restarts the service running the blockchain node."
+start-node-service:
+  description: "This actions starts the service running the blockchain node."
+stop-node-service:
+  description: "This actions stops the service running the blockchain node."
 
 set-node-key:
   description: |

--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,8 @@ options:
       Note 1: needs to point to the sha256 corresponding to the 'binary-url' ahead of downloading the binary to actually perform the check!
 
       Note 2: if multiple binary URL:s are supplied, multiple sha256 URL:s should be supplied as well, in the same order.
+
+      Note 3: it's also possible to provide one sha256 URL with multiple binary URL:s if the sha256 file contains one row per binary.
   docker-tag:
     type: string
     default: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ops == 2.4.1
+ops == 2.9
 requests
 charmhelpers == 1.2.1

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,6 +63,7 @@ class PolkadotCharm(ops.CharmBase):
         self.framework.observe(self.on.stop_node_service_action, self._on_stop_node_service_action)
         self.framework.observe(self.on.set_node_key_action, self._on_set_node_key_action)
         self.framework.observe(self.on.get_node_info_action, self._on_get_node_info_action)
+        self.framework.observe(self.on.get_node_help_action, self._on_get_node_help_action)
 
         self._stored.set_default(binary_url=self.config.get('binary-url'),
                                  docker_tag=self.config.get('docker-tag'),
@@ -243,6 +244,9 @@ class PolkadotCharm(ops.CharmBase):
         except (RequestsConnectionError, NewConnectionError, MaxRetryError) as e:
             logger.warning(e)
             event.set_results(results={'on-chain-info': 'Unable to establish HTTP connection to client'})
+
+    def _on_get_node_help_action(self, event: ops.ActionEvent) -> None:
+        event.set_results(results={'help-output': utils.get_client_binary_help_output()})
 
 
 if __name__ == "__main__":

--- a/src/charm.py
+++ b/src/charm.py
@@ -138,11 +138,11 @@ class PolkadotCharm(ops.CharmBase):
             self.unit.status = ops.BlockedStatus("Service not running")
 
     def _on_start(self, event: ops.StartEvent) -> None:
-        utils.start_polkadot()
+        utils.start_service()
         self.update_status()
 
     def _on_stop(self, event: ops.StopEvent) -> None:
-        utils.stop_polkadot()
+        utils.stop_service()
         self.unit.status = ops.ActiveStatus("Service stopped")
 
     def _on_get_session_key_action(self, event: ops.ActionEvent) -> None:
@@ -175,28 +175,28 @@ class PolkadotCharm(ops.CharmBase):
             PolkadotRpcWrapper(rpc_port).insert_key(mnemonic, address)
 
     def _on_restart_node_service_action(self, event: ops.ActionEvent) -> None:
-        utils.restart_polkadot()
+        utils.restart_service()
         if not utils.service_started():
             event.fail("Could not restart service")
         self.unit.status = ops.ActiveStatus("Node service restarted")
 
     def _on_start_node_service_action(self, event: ops.ActionEvent) -> None:
-        utils.start_polkadot()
+        utils.start_service()
         if not utils.service_started():
             event.fail("Could not start service")
         self.unit.status = ops.ActiveStatus("Node service started")
 
     def _on_stop_node_service_action(self, event: ops.ActionEvent) -> None:
-        utils.stop_polkadot()
+        utils.stop_service()
         if utils.service_started(iterations=1):
             event.fail("Could not stop service")
         self.unit.status = ops.BlockedStatus("Node service stopped")
 
     def _on_set_node_key_action(self, event: ops.ActionEvent) -> None:
         key = event.params['key']
-        utils.stop_polkadot()
+        utils.stop_service()
         utils.write_node_key_file(key)
-        utils.start_polkadot()
+        utils.start_service()
 
     # TODO: this action is getting quite large and specialized, perhaps move all actions to an `actions.py` file?
     def _on_get_node_info_action(self, event: ops.ActionEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -133,9 +133,9 @@ class PolkadotCharm(ops.CharmBase):
                     logger.warning(e)
                     self.unit.status = ops.MaintenanceStatus("Client not responding to HTTP (attempt {}/{})".format(i, connection_attempts))
             if type(self.unit.status) != ops.ActiveStatus:
-                self.unit.status = ops.BlockedStatus("Service running, client starting up")
+                self.unit.status = ops.WaitingStatus("Service running, client starting up")
         else:
-            self.unit.status = ops.WaitingStatus("Service not running")
+            self.unit.status = ops.BlockedStatus("Service not running")
 
     def _on_start(self, event: ops.StartEvent) -> None:
         utils.start_polkadot()

--- a/src/charm.py
+++ b/src/charm.py
@@ -17,9 +17,7 @@ from urllib3.exceptions import NewConnectionError, MaxRetryError
 import time
 import re
 
-from ops import main, framework, ConfigChangedEvent, InstallEvent, StartEvent, StopEvent, UpdateStatusEvent
-from ops.charm import CharmBase, ActionEvent
-from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus, BlockedStatus
+import ops
 
 from interface_prometheus import PrometheusProvider
 from interface_rpc_url_provider import RpcUrlProvider
@@ -32,10 +30,10 @@ from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 logger = logging.getLogger(__name__)
 
 
-class PolkadotCharm(CharmBase):
+class PolkadotCharm(ops.CharmBase):
     """Charm the service."""
 
-    _stored = framework.StoredState()
+    _stored = ops.framework.StoredState()
 
     def __init__(self, *args):
         super().__init__(*args)
@@ -70,40 +68,40 @@ class PolkadotCharm(CharmBase):
                                  docker_tag=self.config.get('docker-tag'),
                                  service_args=self.config.get('service-args'))
 
-    def _on_install(self, event: InstallEvent) -> None:
-        self.unit.status = MaintenanceStatus("Begin installing charm")
+    def _on_install(self, event: ops.InstallEvent) -> None:
+        self.unit.status = ops.MaintenanceStatus("Begin installing charm")
         service_args_obj = ServiceArgs(self.config.get('service-args'))
         # Setup polkadot group and user, disable login
         utils.setup_group_and_user()
         # Create environment file for polkadot service arguments
         utils.create_env_file_for_service()
         # Download and prepare the binary
-        self.unit.status = MaintenanceStatus("Installing binary")
+        self.unit.status = ops.MaintenanceStatus("Installing binary")
         utils.install_binary(self.config, service_args_obj.chain_name)
         # Install polkadot.service file
-        self.unit.status = MaintenanceStatus("Installing service")
+        self.unit.status = ops.MaintenanceStatus("Installing service")
         source_path = Path(self.charm_dir / 'templates/etc/systemd/system/polkadot.service')
         utils.install_service_file(source_path)
         utils.update_service_args(service_args_obj.service_args_string)
-        self.unit.status = MaintenanceStatus("Installing node exporter")
+        self.unit.status = ops.MaintenanceStatus("Installing node exporter")
         utils.install_node_exporter()
-        self.unit.status = MaintenanceStatus("Charm install complete")
+        self.unit.status = ops.MaintenanceStatus("Charm install complete")
 
-    def _on_config_changed(self, event: ConfigChangedEvent) -> None:
+    def _on_config_changed(self, event: ops.ConfigChangedEvent) -> None:
         try:
             service_args_obj = ServiceArgs(self.config.get('service-args'))
         except ValueError as e:
-            self.unit.status = BlockedStatus(str(e))
+            self.unit.status = ops.BlockedStatus(str(e))
             event.defer()
             return
 
         # Update of polkadot binary requested
         if self._stored.binary_url != self.config.get('binary-url') or self._stored.docker_tag != self.config.get('docker-tag'):
-            self.unit.status = MaintenanceStatus("Installing binary")
+            self.unit.status = ops.MaintenanceStatus("Installing binary")
             try:
                 utils.install_binary(self.config, service_args_obj.chain_name)
             except ValueError as e:
-                self.unit.status = BlockedStatus(str(e))
+                self.unit.status = ops.BlockedStatus(str(e))
                 event.defer()
                 return
             self._stored.binary_url = self.config.get('binary-url')
@@ -111,13 +109,13 @@ class PolkadotCharm(CharmBase):
 
         # Update of polkadot service arguments requested
         if self._stored.service_args != self.config.get('service-args'):
-            self.unit.status = MaintenanceStatus("Updating service args")
+            self.unit.status = ops.MaintenanceStatus("Updating service args")
             utils.update_service_args(service_args_obj.service_args_string)
             self._stored.service_args = self.config.get('service-args')
 
         self.update_status(connection_attempts=2)
 
-    def _on_update_status(self, event: UpdateStatusEvent) -> None:
+    def _on_update_status(self, event: ops.UpdateStatusEvent) -> None:
         self.update_status()
 
     def update_status(self, connection_attempts: int = 4) -> None:
@@ -126,28 +124,28 @@ class PolkadotCharm(CharmBase):
             for i in range(connection_attempts):
                 time.sleep(5)
                 try:
-                    self.unit.status = ActiveStatus("Syncing: {}, Validating: {}".format(
+                    self.unit.status = ops.ActiveStatus("Syncing: {}, Validating: {}".format(
                         str(PolkadotRpcWrapper(rpc_port).is_syncing()),
                         str(PolkadotRpcWrapper(rpc_port).is_validating())))
                     self.unit.set_workload_version(PolkadotRpcWrapper(rpc_port).get_version())
                     break
                 except RequestsConnectionError as e:
                     logger.warning(e)
-                    self.unit.status = MaintenanceStatus("Client not responding to HTTP (attempt {}/{})".format(i, connection_attempts))
-            if type(self.unit.status) != ActiveStatus:
-                self.unit.status = BlockedStatus("Service running, client starting up")
+                    self.unit.status = ops.MaintenanceStatus("Client not responding to HTTP (attempt {}/{})".format(i, connection_attempts))
+            if type(self.unit.status) != ops.ActiveStatus:
+                self.unit.status = ops.BlockedStatus("Service running, client starting up")
         else:
-            self.unit.status = WaitingStatus("Service not running")
+            self.unit.status = ops.WaitingStatus("Service not running")
 
-    def _on_start(self, event: StartEvent) -> None:
+    def _on_start(self, event: ops.StartEvent) -> None:
         utils.start_polkadot()
         self.update_status()
 
-    def _on_stop(self, event: StopEvent) -> None:
+    def _on_stop(self, event: ops.StopEvent) -> None:
         utils.stop_polkadot()
-        self.unit.status = ActiveStatus("Service stopped")
+        self.unit.status = ops.ActiveStatus("Service stopped")
 
-    def _on_get_session_key_action(self, event: ActionEvent) -> None:
+    def _on_get_session_key_action(self, event: ops.ActionEvent) -> None:
         event.log("Getting new session key through rpc...")
         rpc_port = ServiceArgs(self._stored.service_args).rpc_port
         key = PolkadotRpcWrapper(rpc_port).get_session_key()
@@ -156,7 +154,7 @@ class PolkadotCharm(CharmBase):
         else:
             event.fail("Unable to get new session key")
 
-    def _on_has_session_key_action(self, event: ActionEvent) -> None:
+    def _on_has_session_key_action(self, event: ops.ActionEvent) -> None:
         key = event.params['key']
         keypattern = re.compile(r'^0x')
         if not re.match(keypattern, key):
@@ -166,7 +164,7 @@ class PolkadotCharm(CharmBase):
             has_session_key = PolkadotRpcWrapper(rpc_port).has_session_key(key)
             event.set_results(results={'has-key': has_session_key})
 
-    def _on_insert_key_action(self, event: ActionEvent) -> None:
+    def _on_insert_key_action(self, event: ops.ActionEvent) -> None:
         mnemonic = event.params['mnemonic']
         address = event.params['address']
         keypattern = re.compile(r'^0x')
@@ -176,32 +174,32 @@ class PolkadotCharm(CharmBase):
             rpc_port = ServiceArgs(self._stored.service_args).rpc_port
             PolkadotRpcWrapper(rpc_port).insert_key(mnemonic, address)
 
-    def _on_restart_node_service_action(self, event: ActionEvent) -> None:
+    def _on_restart_node_service_action(self, event: ops.ActionEvent) -> None:
         utils.restart_polkadot()
         if not utils.service_started():
             event.fail("Could not restart service")
-        self.unit.status = ActiveStatus("Node service restarted")
+        self.unit.status = ops.ActiveStatus("Node service restarted")
 
-    def _on_start_node_service_action(self, event: ActionEvent) -> None:
+    def _on_start_node_service_action(self, event: ops.ActionEvent) -> None:
         utils.start_polkadot()
         if not utils.service_started():
             event.fail("Could not start service")
-        self.unit.status = ActiveStatus("Node service started")
+        self.unit.status = ops.ActiveStatus("Node service started")
 
-    def _on_stop_node_service_action(self, event: ActionEvent) -> None:
+    def _on_stop_node_service_action(self, event: ops.ActionEvent) -> None:
         utils.stop_polkadot()
         if utils.service_started(iterations=1):
             event.fail("Could not stop service")
-        self.unit.status = BlockedStatus("Node service stopped")
+        self.unit.status = ops.BlockedStatus("Node service stopped")
 
-    def _on_set_node_key_action(self, event: ActionEvent) -> None:
+    def _on_set_node_key_action(self, event: ops.ActionEvent) -> None:
         key = event.params['key']
         utils.stop_polkadot()
         utils.write_node_key_file(key)
         utils.start_polkadot()
 
     # TODO: this action is getting quite large and specialized, perhaps move all actions to an `actions.py` file?
-    def _on_get_node_info_action(self, event: ActionEvent) -> None:
+    def _on_get_node_info_action(self, event: ops.ActionEvent) -> None:
         # Disk usage
         relay_du = utils.get_relay_disk_usage()
         chain_du = utils.get_chain_disk_usage()
@@ -248,4 +246,4 @@ class PolkadotCharm(CharmBase):
 
 
 if __name__ == "__main__":
-    main.main(PolkadotCharm)
+    ops.main(PolkadotCharm)

--- a/src/docker.py
+++ b/src/docker.py
@@ -65,11 +65,11 @@ class Docker():
             raise ValueError(f"Could not pull {docker_image_and_tag} check 'docker-tag'!") from err
 
         sp.run(['docker', 'create', '--name', 'tmp', docker_image_and_tag], check=False)
-        utils.stop_polkadot()
+        utils.stop_service()
         sp.run(['docker', 'cp', f'tmp:{docker_binary_path}', utils.BINARY_PATH], check=True)
         if docker_specs_path:
             sp.run(['docker', 'cp', f'tmp:{docker_specs_path}', utils.HOME_PATH], check=True)
             sp.run(['chown', '-R', 'polkadot:polkadot', Path(utils.HOME_PATH, Path(docker_specs_path).name)], check=True)
-        utils.start_polkadot()
+        utils.start_service()
         sp.run(['docker', 'rm', 'tmp'], check=True)
         sp.run(['docker', 'rmi', docker_image_and_tag], check=True)

--- a/src/utils.py
+++ b/src/utils.py
@@ -372,3 +372,13 @@ def get_wasm_info() -> str:
         files = [str(f.name) for f in files]
         return ', '.join(files)
     return "~/wasm directory not found"
+
+
+def get_client_binary_help_output() -> str:
+    if BINARY_PATH.exists():
+        command = f'.{BINARY_PATH} --help'
+        process = sp.run(command, stdout=sp.PIPE, cwd='/', shell=True, check=False)
+        if process.returncode == 0:
+            return process.stdout.decode('utf-8').strip()
+        return "Could not parse client binary '--help' command"
+    return "Client binary not found"

--- a/src/utils.py
+++ b/src/utils.py
@@ -69,14 +69,14 @@ def install_deb_from_url(url: str) -> None:
         f.write(deb_response.content)
     package_name = sp.check_output(['dpkg-deb', '-f', deb_path, 'Package']).decode('utf-8').strip()
     logger.debug('Installing package %s from deb file %s', package_name, str(deb_path))
-    stop_polkadot()
+    stop_service()
     sp.check_call(['dpkg', '--purge', package_name])
     sp.check_call(['dpkg', '--install', deb_path])
     installed_binary = find_binary_installed_by_deb(package_name)
     if os.path.exists(BINARY_PATH):
         os.remove(BINARY_PATH)
     os.symlink(installed_binary, BINARY_PATH)
-    start_polkadot()
+    start_service()
     os.remove(deb_path)
 
 
@@ -106,7 +106,7 @@ def install_binaries_from_urls(binary_urls: str, sha256_urls: str) -> None:
         binary_name = binary_url.split('/')[-1]
         responses += [(binary_url, sha256_url, response, binary_name, binary_hash)]
     perform_sha256_checksums(responses, sha256_urls)
-    stop_polkadot()
+    stop_service()
     for binary_url, _, response, binary_name, _ in responses:
         logger.debug("Unpack binary downloaded from: %s", binary_url)
         binary_path = HOME_PATH / binary_name
@@ -114,7 +114,7 @@ def install_binaries_from_urls(binary_urls: str, sha256_urls: str) -> None:
             f.write(response.content)
             sp.run(['chown', f'{USER}:{USER}', binary_path], check=False)
             sp.run(['chmod', '+x', binary_path], check=False)
-    start_polkadot()
+    start_service()
 
 
 def install_binary_from_url(url: str, sha256_url: str) -> None:
@@ -126,12 +126,12 @@ def install_binary_from_url(url: str, sha256_url: str) -> None:
     if sha256_url:
         binary_hash = hashlib.sha256(binary_response.content).hexdigest()
         perform_sha256_checksum(binary_hash, sha256_url)
-    stop_polkadot()
+    stop_service()
     with open(BINARY_PATH, 'wb') as f:
         f.write(binary_response.content)
         sp.run(['chown', f'{USER}:{USER}', BINARY_PATH], check=False)
         sp.run(['chmod', '+x', BINARY_PATH], check=False)
-    start_polkadot()
+    start_service()
 
 
 def perform_sha256_checksums(responses: list, sha256_urls: str) -> None:
@@ -248,18 +248,18 @@ def get_binary_last_changed() -> str:
     return ""
 
 
-def restart_polkadot():
+def restart_service():
     sp.run(['systemctl', 'restart', f'{USER}.service'], check=False)
 
 
-def start_polkadot():
+def start_service():
     # TODO: remove chown and chmod from here? Runs in the install hook already
     sp.run(['chown', f'{USER}:{USER}', BINARY_PATH], check=False)
     sp.run(['chmod', '+x', BINARY_PATH], check=False)
     sp.run(['systemctl', 'start', f'{USER}.service'], check=False)
 
 
-def stop_polkadot():
+def stop_service():
     sp.run(['systemctl', 'stop', f'{USER}.service'], check=False)
 
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -248,8 +248,8 @@ def get_binary_last_changed() -> str:
     return ""
 
 
-def stop_polkadot():
-    sp.run(['systemctl', 'stop', f'{USER}.service'], check=False)
+def restart_polkadot():
+    sp.run(['systemctl', 'restart', f'{USER}.service'], check=False)
 
 
 def start_polkadot():
@@ -259,12 +259,16 @@ def start_polkadot():
     sp.run(['systemctl', 'start', f'{USER}.service'], check=False)
 
 
+def stop_polkadot():
+    sp.run(['systemctl', 'stop', f'{USER}.service'], check=False)
+
+
 def service_started(iterations: int = 3) -> bool:
     for _ in range(iterations):
         service_status = os.system('service polkadot status')
         if service_status == 0:
             return True
-        time.sleep(5)
+        time.sleep(4)
     return False
 
 


### PR DESCRIPTION
Charm updates to be included in Revision 14.

- [Updated binary-sha256-url description](https://github.com/dwellir-public/polkadot-operator/pull/31/commits/17e41d408803d251551a13c705eb824eb1c3fb35)
- [Add actions to stop and to start the polkadot service](https://github.com/dwellir-public/polkadot-operator/pull/31/commits/63001b2f7cb27ff21c9077689d92230a73ccd626)
- [Some readme updates and restructuring](https://github.com/dwellir-public/polkadot-operator/pull/31/commits/4db285d3e06065f04dbbd117da70d011ba192e0b)
- [Upgrade ops version to 2.9](https://github.com/dwellir-public/polkadot-operator/pull/31/commits/b7c43a9a85776d3efc2c7893cb84632a37b48503)
  - [v2.8](https://github.com/canonical/operator/releases/tag/2.8.0) comes with a `Unit.reboot()` implementation and [v2.9](https://github.com/canonical/operator/releases/tag/2.9.0) has support for Python 3.12 :tada:
- [Change operator framework imports to 'import ops' style](https://github.com/dwellir-public/polkadot-operator/pull/31/commits/d6aa353973b849f6aea478bc0a2485cf8d572b84)
- [Update how update_status sets its status](https://github.com/dwellir-public/polkadot-operator/pull/31/commits/e5b20e774909be92d003045e908e3c2444158d60)
- [Rename start_polkadot to start_service (also for stop, restart)](https://github.com/dwellir-public/polkadot-operator/pull/31/commits/c21ca719f61396f81af45ff6fce1ba202a77b223)
- [Add action to get output from './polkadot --help'](https://github.com/dwellir-public/polkadot-operator/pull/31/commits/ed33e21d00ec9f818fdcaa5cf99303c068024412)