### PR TITLE
Using substrate-interface lib for session key actions.

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -43,6 +43,11 @@ set-node-key:
       type: string
   required: [ key ]
 
+find-validator:
+  description: |
+    Checks if node has a session key present on-chain, using a RPC call. If it does, it means it is currently producing blocks.
+    Returns the validator/collator address if a session key is found. Else False.
+
 get-node-info:
   description: |
     Gets system information about the node and its container.

--- a/actions.yaml
+++ b/actions.yaml
@@ -45,21 +45,22 @@ set-node-key:
 
 find-validator-address:
   description: |
-    Checks if this node is currently validating for any address, using an RPC call.
-    Returns the validator/collator address if a session key is found. Else False.
+    Checks if this node is currently validating for any validator address found on-chain.
+    It does so by checking if any session key on-chain is present on this node.
+    Returns the validator address and the session key if this node is validating.
 
 is-validating-this-era:
   description: |
-    Checks if node has a session key present on-chain this era for the validator address set in config, using an RPC call.
-    If it does, it means it is currently producing blocks.
-    Returns the session key if found. Else False.
+    Checks if this node is currently validating for the validator address set in config.
+    It does so by checking if the session key used for that validator is present on this node.
+    Returns a message whether this node is validating or not. If it is validating, the session key is returned as well.
     REQUIRES validator-address config parameter to be set.
 
 is-validating-next-era:
   description: |
-    Checks if node has a session key present on-chain to validate next era, using an RPC call.
-    If it does, it means it will start producing blocks next era.
-    Returns the session key if found. Else False.
+    Checks if this node will be validating next era for the validator address set in config.
+    It does so by checking if the session key that will be used for that validator is present on this node.
+    Returns a message whether this node will be validating next era or not. If it will, the session key is returned as well.
     REQUIRES validator-address config parameter to be set.
 
 get-node-info:

--- a/actions.yaml
+++ b/actions.yaml
@@ -5,7 +5,7 @@ get-session-key:
   description: "Runs author_rotateKeys and returns a new session-key."
 
 has-session-key:
-  description: "Checks if node has a session key, using a RPC call."
+  description: "Checks if node has a session key, using an RPC call."
   params:
     key:
       description: "Key to check if exist on node. E.g. key='0xhjd39djk309'"
@@ -45,19 +45,19 @@ set-node-key:
 
 find-validator-address:
   description: |
-    Checks if this node is currently validating for any address, using a RPC call.
+    Checks if this node is currently validating for any address, using an RPC call.
     Returns the validator/collator address if a session key is found. Else False.
 
 is-validating-this-era:
   description: |
-    Checks if node has a session key present on-chain this era for the validator address set in config, using a RPC call.
+    Checks if node has a session key present on-chain this era for the validator address set in config, using an RPC call.
     If it does, it means it is currently producing blocks.
     Returns the session key if found. Else False.
     REQUIRES validator-address config parameter to be set.
 
 is-validating-next-era:
   description: |
-    Checks if node has a session key present on-chain to validate next era, using a RPC call.
+    Checks if node has a session key present on-chain to validate next era, using an RPC call.
     If it does, it means it will start producing blocks next era.
     Returns the session key if found. Else False.
     REQUIRES validator-address config parameter to be set.

--- a/actions.yaml
+++ b/actions.yaml
@@ -43,10 +43,24 @@ set-node-key:
       type: string
   required: [ key ]
 
-find-validator:
+find-validator-address:
   description: |
-    Checks if node has a session key present on-chain, using a RPC call. If it does, it means it is currently producing blocks.
+    Checks if this node is currently validating for any address, using a RPC call.
     Returns the validator/collator address if a session key is found. Else False.
+
+is-validating-this-era:
+  description: |
+    Checks if node has a session key present on-chain this era for the validator address set in config, using a RPC call.
+    If it does, it means it is currently producing blocks.
+    Returns the session key if found. Else False.
+    REQUIRES validator-address config parameter to be set.
+
+is-validating-next-era:
+  description: |
+    Checks if node has a session key present on-chain to validate next era, using a RPC call.
+    If it does, it means it will start producing blocks next era.
+    Returns the session key if found. Else False.
+    REQUIRES validator-address config parameter to be set.
 
 get-node-info:
   description: |

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -2,14 +2,15 @@ type: charm
 bases:
   - build-on:
       - name: ubuntu
-        channel: "22.04"
+        channel: "20.04"
     run-on:
       - name: ubuntu
         channel: "20.04"
         architectures: [amd64]
+  - build-on:
       - name: ubuntu
-        channel: "21.10"
-        architectures: [amd64]
+        channel: "22.04"
+    run-on:
       - name: ubuntu
         channel: "22.04"
         architectures: [amd64]

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -18,6 +18,9 @@ bases:
 # This below is needed for charmhelpers 0.20.24 to build
 parts:
   charm:
-    charm-python-packages: [setuptools < 58]
+    charm-python-packages:
+      - setuptools < 58
+    charm-binary-python-packages:
+      - substrate-interface
     prime:
       - files/*

--- a/config.yaml
+++ b/config.yaml
@@ -39,3 +39,9 @@ options:
       Extra arguments that the service should run with.
 
       '--chain=... --rpc-port=...' are required to set for the charm to run.
+  validator-address:
+    type: string
+    default: ""
+    description: |
+      If this is set, update-status will check if this node is currently validating for this address.
+      HINT: if this config parameter is set, the actions is-validating-this-era and is-validating-next-era can be used.

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,6 +62,7 @@ class PolkadotCharm(ops.CharmBase):
         self.framework.observe(self.on.start_node_service_action, self._on_start_node_service_action)
         self.framework.observe(self.on.stop_node_service_action, self._on_stop_node_service_action)
         self.framework.observe(self.on.set_node_key_action, self._on_set_node_key_action)
+        self.framework.observe(self.on.find_validator_action, self._on_find_validator_action)
         self.framework.observe(self.on.get_node_info_action, self._on_get_node_info_action)
         self.framework.observe(self.on.get_node_help_action, self._on_get_node_help_action)
 
@@ -198,6 +199,15 @@ class PolkadotCharm(ops.CharmBase):
         utils.stop_service()
         utils.write_node_key_file(key)
         utils.start_service()
+
+    def _on_find_validator_action(self, event: ActionEvent) -> None:
+        event.log("Checking sessions key through rpc...")
+        rpc_port = ServiceArgs(self._stored.service_args).rpc_port
+        validator = PolkadotRpcWrapper(rpc_port).find_validator()
+        if validator:
+            event.set_results(results={'validator': validator})
+        else:
+            event.fail("This node has no session key on-chain.")
 
     # TODO: this action is getting quite large and specialized, perhaps move all actions to an `actions.py` file?
     def _on_get_node_info_action(self, event: ops.ActionEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,7 +62,9 @@ class PolkadotCharm(ops.CharmBase):
         self.framework.observe(self.on.start_node_service_action, self._on_start_node_service_action)
         self.framework.observe(self.on.stop_node_service_action, self._on_stop_node_service_action)
         self.framework.observe(self.on.set_node_key_action, self._on_set_node_key_action)
-        self.framework.observe(self.on.find_validator_action, self._on_find_validator_action)
+        self.framework.observe(self.on.find_validator_address_action, self._on_find_validator_address_action)
+        self.framework.observe(self.on.is_validating_this_era_action, self._on_is_validating_this_era_action)
+        self.framework.observe(self.on.is_validating_next_era_action, self._on_is_validating_next_era_action)
         self.framework.observe(self.on.get_node_info_action, self._on_get_node_info_action)
         self.framework.observe(self.on.get_node_help_action, self._on_get_node_help_action)
 
@@ -126,9 +128,17 @@ class PolkadotCharm(ops.CharmBase):
             for i in range(connection_attempts):
                 time.sleep(5)
                 try:
-                    self.unit.status = ops.ActiveStatus("Syncing: {}, Validating: {}".format(
-                        str(PolkadotRpcWrapper(rpc_port).is_syncing()),
-                        str(PolkadotRpcWrapper(rpc_port).is_validating())))
+                    is_syncing = str(PolkadotRpcWrapper(rpc_port).is_syncing())
+                    status_message = f'Syncing: {is_syncing}'
+                    address = self.config.get('validator-address')
+                    if address:
+                        if PolkadotRpcWrapper(rpc_port).is_validating_this_era(address):
+                            status_message += ", Validating: Yes"
+                        elif PolkadotRpcWrapper(rpc_port).is_validating_next_era(address):
+                            status_message += ", Validating: Next Era"
+                        else:
+                            status_message += ", Validating: No"
+                    self.unit.status = ops.ActiveStatus(status_message)
                     self.unit.set_workload_version(PolkadotRpcWrapper(rpc_port).get_version())
                     break
                 except RequestsConnectionError as e:
@@ -200,14 +210,40 @@ class PolkadotCharm(ops.CharmBase):
         utils.write_node_key_file(key)
         utils.start_service()
 
-    def _on_find_validator_action(self, event: ActionEvent) -> None:
+    def _on_find_validator_address_action(self, event: ops.ActionEvent) -> None:
         event.log("Checking sessions key through rpc...")
         rpc_port = ServiceArgs(self._stored.service_args).rpc_port
-        validator = PolkadotRpcWrapper(rpc_port).find_validator()
+        validator = PolkadotRpcWrapper(rpc_port).find_validator_address()
         if validator:
             event.set_results(results={'validator': validator})
         else:
-            event.fail("This node has no session key on-chain.")
+            event.set_results(results={'message': 'This node is not currently validating for any address.'})
+
+    def _on_is_validating_this_era_action(self, event: ops.ActionEvent) -> None:
+        validator_address = self.config.get("validator-address")
+        if not validator_address:
+            event.fail("Set validator-address config parameter to use this action!")
+            return
+        event.log("Checking sessions key through rpc...")
+        rpc_port = ServiceArgs(self._stored.service_args).rpc_port
+        session_key = PolkadotRpcWrapper(rpc_port).is_validating_this_era(validator_address)
+        if session_key:
+            event.set_results(results={'session_key': session_key})
+        else:
+            event.set_results(results={'message': f'This node is not currently validating for address {validator_address}.'})
+
+    def _on_is_validating_next_era_action(self, event: ops.ActionEvent) -> None:
+        validator_address = self.config.get("validator-address")
+        if not validator_address:
+            event.fail("Set validator-address config parameter to use this action!")
+            return
+        event.log("Checking sessions key through rpc...")
+        rpc_port = ServiceArgs(self._stored.service_args).rpc_port
+        session_key = PolkadotRpcWrapper(rpc_port).is_validating_next_era(validator_address)
+        if session_key:
+            event.set_results(results={'session_key': session_key})
+        else:
+            event.set_results(results={'message': f'This node will not be validating next era for address {validator_address}.'})
 
     # TODO: this action is getting quite large and specialized, perhaps move all actions to an `actions.py` file?
     def _on_get_node_info_action(self, event: ops.ActionEvent) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -213,9 +213,10 @@ class PolkadotCharm(ops.CharmBase):
     def _on_find_validator_address_action(self, event: ops.ActionEvent) -> None:
         event.log("Checking sessions key through rpc...")
         rpc_port = ServiceArgs(self._stored.service_args).rpc_port
-        validator = PolkadotRpcWrapper(rpc_port).find_validator_address()
-        if validator:
-            event.set_results(results={'validator': validator})
+        result = PolkadotRpcWrapper(rpc_port).find_validator_address()
+        if result:
+            event.set_results(results={'validator': result["validator"]})
+            event.set_results(results={'session-key': result["session_key"]})
         else:
             event.set_results(results={'message': 'This node is not currently validating for any address.'})
 
@@ -228,6 +229,7 @@ class PolkadotCharm(ops.CharmBase):
         rpc_port = ServiceArgs(self._stored.service_args).rpc_port
         session_key = PolkadotRpcWrapper(rpc_port).is_validating_this_era(validator_address)
         if session_key:
+            event.set_results(results={'message': f'This node is currently validating for address {validator_address}.'})
             event.set_results(results={'session_key': session_key})
         else:
             event.set_results(results={'message': f'This node is not currently validating for address {validator_address}.'})
@@ -241,6 +243,7 @@ class PolkadotCharm(ops.CharmBase):
         rpc_port = ServiceArgs(self._stored.service_args).rpc_port
         session_key = PolkadotRpcWrapper(rpc_port).is_validating_next_era(validator_address)
         if session_key:
+            event.set_results(results={'message': f'This node will be validating next era for address {validator_address}.'})
             event.set_results(results={'session_key': session_key})
         else:
             event.set_results(results={'message': f'This node will not be validating next era for address {validator_address}.'})

--- a/src/polkadot_rpc_wrapper.py
+++ b/src/polkadot_rpc_wrapper.py
@@ -110,7 +110,7 @@ class PolkadotRpcWrapper():
                 # Some chains uses multiple keys. Before checking if it exist on the node they need to be concatenated removing preceding '0x'.
                 session_key += k[2:]
             if self.has_session_key(session_key):
-                return validator[0]
+                return {"validator": validator[0], "session_key": session_key}
         return False
 
     def is_validating_next_era(self, address):

--- a/src/polkadot_rpc_wrapper.py
+++ b/src/polkadot_rpc_wrapper.py
@@ -4,7 +4,7 @@ import requests
 import json
 import re
 from typing import Tuple
-import substrateinterface
+from substrateinterface import SubstrateInterface
 
 class PolkadotRpcWrapper():
 
@@ -101,7 +101,7 @@ class PolkadotRpcWrapper():
         It does so by checking if any session key currently on-chain is present on this node.
         :return: the validator/collator address or False.
         """
-        substrate = substrateinterface.SubstrateInterface(url=self.__server_address)
+        substrate = SubstrateInterface(url=self.__server_address)
         result = substrate.query("Session", "QueuedKeys").value_serialized
         for validator in result:
             keys = validator[1]
@@ -120,7 +120,7 @@ class PolkadotRpcWrapper():
         And if that session key exist on this node.
         :return: the session key if found on this node, else False.
         """
-        substrate = substrateinterface.SubstrateInterface(url=self.__server_address)
+        substrate = SubstrateInterface(url=self.__server_address)
         result = substrate.query("Session", "NextKeys", [address]).value_serialized
         if result:
             session_key = '0x'
@@ -137,7 +137,7 @@ class PolkadotRpcWrapper():
         And if that session key exist on this node.
         :return: the session key if validating, else False.
         """
-        substrate = substrateinterface.SubstrateInterface(url=self.__server_address)
+        substrate = SubstrateInterface(url=self.__server_address)
         result = substrate.query("Session", "QueuedKeys").value_serialized
         for validator in result:
             if validator[0] == address:


### PR DESCRIPTION
Using substrate-interface Python library to make more advanced RPC calls. Today it is quite difficult and annoying to find out which node is validating. One typically go to `polkadot.js` to find out which session key a validator is using. And then check if that session key exist on any of our nodes. With these actions it can be done directly on the node instead. I also improved the `Validating` status message to actually show if the node is currently validating or will be next era. So basically it would be enough to just run `juju status` to know if the node is validating.

No rush with this PR. I would also need to test it on a real validator first to test all the functionality.