### PR TITLE
Add GitHub workflow for validating source branch for pull requests to…

### DIFF
--- a/github/workflows/validate-source-branch.yaml
+++ b/github/workflows/validate-source-branch.yaml
@@ -1,0 +1,18 @@
+name: Validate pull request source branch
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+jobs:
+  validate-source-branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate source branch
+        run: |
+          if [ ${{ github.head_ref }} != "develop" ] && [ ${{ github.base_ref }} == "main" ]; then
+            echo "Merge requests to the main branch are only allowed from the develop branch."
+            exit 1
+          fi


### PR DESCRIPTION
… main

Using GitHub workflows seems to be the way to do a custom protection like this, what you asked for here: https://github.com/dwellir-public/polkadot-operator/pull/33#issuecomment-1880535830

After this is merged, we can turn on **Require status checks to pass before merging** in the branch protection rules for `main`.

Sounds good?