### PR TITLE
Add Polkadex mainnet as custom chain name for Docker and spec file

### DIFF
--- a/src/docker.py
+++ b/src/docker.py
@@ -51,6 +51,8 @@ class Docker():
             self.__extract_from_docker('cloverio/clover-para', '/opt/clover/bin/clover', '/opt/specs')
         elif self.chain_name == 'polkadex':
             self.__extract_from_docker('polkadex/parachain', '/data/bin/parachain-polkadex-node', '/data/polkadot-parachain-raw.json')
+        elif self.chain_name == 'polkadex-mainnet':
+            self.__extract_from_docker('polkadex/mainnet', '/usr/local/bin/polkadex-node', '/data/customSpecRaw.json')
         elif self.chain_name in ['crust-mainnet', 'crust-maxwell', 'crust-rocky']:
             self.__extract_from_docker('crustio/crust', '/opt/crust/crust')
         else:

--- a/src/service_args.py
+++ b/src/service_args.py
@@ -118,6 +118,8 @@ class ServiceArgs():
             self.__clover()
         elif self.chain_name == 'polkadex':
             self.__polkadex()
+        elif self.chain_name == 'polkadex-mainnet':
+            self.__polkadex_mainnet()
         elif self.chain_name in ['unique', 'quartz']:
             self.__unique()
         elif self.chain_name in ['crust-mainnet', 'crust-maxwell', 'crust-rocky']:
@@ -210,6 +212,9 @@ class ServiceArgs():
     def __polkadex(self):
         self.__replace_chain_name(Path(utils.HOME_PATH, 'polkadot-parachain-raw.json'), 0)
 
+    def __polkadex_mainnet(self):
+        self.__replace_chain_name(Path(utils.HOME_PATH, 'customSpecRaw.json'), 0)
+
     def __unique(self):
         if self.chain_name == 'unique':
             chain_json_url = 'https://raw.githubusercontent.com/UniqueNetwork/unique-chain/master/chain-specs/unique.json'
@@ -245,4 +250,3 @@ class ServiceArgs():
         chain_json_path = f'{utils.CHAIN_SPEC_PATH}/{self.chain_name}.json'
         utils.download_chain_spec(chain_json_url, f'{self.chain_name}.json')
         self.__replace_chain_name(chain_json_path, 0)
-


### PR DESCRIPTION
Adds Polkadex mainnet as custom option for `--chain`, includes both Docker client install and Docker spec file install.

The spec file part might not be necessary at length, due to https://github.com/dwellir-public/polkadot-operator/pull/36, but since I have to add the Docker specialization I'm throwing it in there for now anyway.

Deploying nodes with a local build of this commit.