### PR TITLE
Add client binary version get for update_status_simple

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -166,7 +166,7 @@ class PolkadotCharm(ops.CharmBase):
                         else:
                             status_message += ", Validating: No"
                     self.unit.status = ops.ActiveStatus(status_message)
-                    self.unit.set_workload_version(PolkadotRpcWrapper(rpc_port).get_version())
+                    self.unit.set_workload_version(utils.get_binary_version())
                     break
                 except RequestsConnectionError as e:
                     logger.warning(e)

--- a/src/charm.py
+++ b/src/charm.py
@@ -186,6 +186,7 @@ class PolkadotCharm(ops.CharmBase):
             self.unit.status = ops.ActiveStatus("Service running")
         else:
             self.unit.status = ops.BlockedStatus("Service not running")
+        self.unit.set_workload_version(utils.get_binary_version())
 
     def _on_start(self, event: ops.StartEvent) -> None:
         utils.start_service()

--- a/src/utils.py
+++ b/src/utils.py
@@ -275,11 +275,16 @@ def install_node_exporter():
 
 
 def get_binary_version() -> str:
+    """ Returns the version of the binary client by checking the '--version' flag. """
+    logger.debug("Getting binary version from client binary.")
     if c.BINARY_PATH.exists():
-        command = [c.BINARY_PATH, "--version"]
-        output = sp.run(command, stdout=sp.PIPE, check=False).stdout.decode('utf-8').strip()
-        version = re.search(r'([\d.]+)', output).group(1)
-        return version
+        try:
+            command = [c.BINARY_PATH, "--version"]
+            output = sp.run(command, stdout=sp.PIPE, check=False).stdout.decode('utf-8').strip()
+            version = re.search(r'([\d.]+)', output).group(1)
+            return version
+        except (sp.SubprocessError, IndexError, AttributeError) as e:
+            logger.error("Couldn't get binary version: %s", {e})
     return ""
 
 


### PR DESCRIPTION
With this, we'll get a version check with each of the `update_status_simple` calls as per [the idea from the previous PR](https://github.com/dwellir-public/polkadot-operator/pull/55#issuecomment-2028897449).