### PR TITLE
Clean up constants based on file/dir

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -2,8 +2,8 @@
 
 from pathlib import Path
 
-USER_DIR = 'polkadot'
-SERVICE_NAME = USER_DIR
+USER = 'polkadot'
+SERVICE_NAME = USER
 HOME_DIR = Path('/home/polkadot')
 BINARY_PATH_FILE = Path(HOME_DIR, 'polkadot')
 CHAIN_SPEC_PATH_DIR = Path(HOME_DIR, 'spec')

--- a/src/constants.py
+++ b/src/constants.py
@@ -5,9 +5,9 @@ from pathlib import Path
 USER = 'polkadot'
 SERVICE_NAME = USER
 HOME_DIR = Path('/home/polkadot')
-BINARY_PATH_FILE = Path(HOME_DIR, 'polkadot')
-CHAIN_SPEC_PATH_DIR = Path(HOME_DIR, 'spec')
-NODE_KEY_PATH_FILE = Path(HOME_DIR, 'node-key')
-DB_CHAIN_PATH_DIR = Path(HOME_DIR, '.local/share/polkadot/chains')
-DB_RELAY_PATH_DIR = Path(HOME_DIR, '.local/share/polkadot/polkadot')
-WASM_PATH_DIR = Path(HOME_DIR, 'wasm')
+BINARY_FILE = Path(HOME_DIR, 'polkadot')
+CHAIN_SPEC_DIR = Path(HOME_DIR, 'spec')
+NODE_KEY_FILE = Path(HOME_DIR, 'node-key')
+DB_CHAIN_DIR = Path(HOME_DIR, '.local/share/polkadot/chains')
+DB_RELAY_DIR = Path(HOME_DIR, '.local/share/polkadot/polkadot')
+WASM_DIR = Path(HOME_DIR, 'wasm')

--- a/src/constants.py
+++ b/src/constants.py
@@ -2,12 +2,12 @@
 
 from pathlib import Path
 
-USER = 'polkadot'
-SERVICE_NAME = USER
-HOME_PATH = Path('/home/polkadot')
-BINARY_PATH = Path(HOME_PATH, 'polkadot')
-CHAIN_SPEC_PATH = Path(HOME_PATH, 'spec')
-NODE_KEY_PATH = Path(HOME_PATH, 'node-key')
-DB_CHAIN_PATH = Path(HOME_PATH, '.local/share/polkadot/chains')
-DB_RELAY_PATH = Path(HOME_PATH, '.local/share/polkadot/polkadot')
-WASM_PATH = Path(HOME_PATH, 'wasm')
+USER_DIR = 'polkadot'
+SERVICE_NAME = USER_DIR
+HOME_PATH_DIR = Path('/home/polkadot')
+BINARY_PATH_FILE = Path(HOME_PATH_DIR, 'polkadot')
+CHAIN_SPEC_PATH_DIR = Path(HOME_PATH_DIR, 'spec')
+NODE_KEY_PATH_FILE = Path(HOME_PATH_DIR, 'node-key')
+DB_CHAIN_PATH_DIR = Path(HOME_PATH_DIR, '.local/share/polkadot/chains')
+DB_RELAY_PATH_DIR = Path(HOME_PATH_DIR, '.local/share/polkadot/polkadot')
+WASM_PATH_DIR = Path(HOME_PATH_DIR, 'wasm')

--- a/src/constants.py
+++ b/src/constants.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 USER_DIR = 'polkadot'
 SERVICE_NAME = USER_DIR
-HOME_PATH_DIR = Path('/home/polkadot')
-BINARY_PATH_FILE = Path(HOME_PATH_DIR, 'polkadot')
-CHAIN_SPEC_PATH_DIR = Path(HOME_PATH_DIR, 'spec')
-NODE_KEY_PATH_FILE = Path(HOME_PATH_DIR, 'node-key')
-DB_CHAIN_PATH_DIR = Path(HOME_PATH_DIR, '.local/share/polkadot/chains')
-DB_RELAY_PATH_DIR = Path(HOME_PATH_DIR, '.local/share/polkadot/polkadot')
-WASM_PATH_DIR = Path(HOME_PATH_DIR, 'wasm')
+HOME_DIR = Path('/home/polkadot')
+BINARY_PATH_FILE = Path(HOME_DIR, 'polkadot')
+CHAIN_SPEC_PATH_DIR = Path(HOME_DIR, 'spec')
+NODE_KEY_PATH_FILE = Path(HOME_DIR, 'node-key')
+DB_CHAIN_PATH_DIR = Path(HOME_DIR, '.local/share/polkadot/chains')
+DB_RELAY_PATH_DIR = Path(HOME_DIR, '.local/share/polkadot/polkadot')
+WASM_PATH_DIR = Path(HOME_DIR, 'wasm')

--- a/src/docker.py
+++ b/src/docker.py
@@ -82,10 +82,10 @@ class Docker():
 
         sp.run(['docker', 'create', '--name', 'tmp', docker_image_and_tag], check=False)
         utils.stop_service()
-        sp.run(['docker', 'cp', f'tmp:{docker_binary_path}', c.BINARY_PATH], check=True)
+        sp.run(['docker', 'cp', f'tmp:{docker_binary_path}', c.BINARY_PATH_FILE], check=True)
         if docker_specs_path:
-            sp.run(['docker', 'cp', f'tmp:{docker_specs_path}', c.HOME_PATH], check=True)
-            sp.run(['chown', '-R', 'polkadot:polkadot', Path(c.HOME_PATH, Path(docker_specs_path).name)], check=True)
+            sp.run(['docker', 'cp', f'tmp:{docker_specs_path}', c.HOME_PATH_DIR], check=True)
+            sp.run(['chown', '-R', 'polkadot:polkadot', Path(c.HOME_PATH_DIR, Path(docker_specs_path).name)], check=True)
         utils.start_service()
         sp.run(['docker', 'rm', 'tmp'], check=True)
         sp.run(['docker', 'rmi', docker_image_and_tag], check=True)

--- a/src/docker.py
+++ b/src/docker.py
@@ -82,7 +82,7 @@ class Docker():
 
         sp.run(['docker', 'create', '--name', 'tmp', docker_image_and_tag], check=False)
         utils.stop_service()
-        sp.run(['docker', 'cp', f'tmp:{docker_binary_path}', c.BINARY_PATH_FILE], check=True)
+        sp.run(['docker', 'cp', f'tmp:{docker_binary_path}', c.BINARY_FILE], check=True)
         if docker_specs_path:
             sp.run(['docker', 'cp', f'tmp:{docker_specs_path}', c.HOME_DIR], check=True)
             sp.run(['chown', '-R', 'polkadot:polkadot', Path(c.HOME_DIR, Path(docker_specs_path).name)], check=True)

--- a/src/docker.py
+++ b/src/docker.py
@@ -84,8 +84,8 @@ class Docker():
         utils.stop_service()
         sp.run(['docker', 'cp', f'tmp:{docker_binary_path}', c.BINARY_PATH_FILE], check=True)
         if docker_specs_path:
-            sp.run(['docker', 'cp', f'tmp:{docker_specs_path}', c.HOME_PATH_DIR], check=True)
-            sp.run(['chown', '-R', 'polkadot:polkadot', Path(c.HOME_PATH_DIR, Path(docker_specs_path).name)], check=True)
+            sp.run(['docker', 'cp', f'tmp:{docker_specs_path}', c.HOME_DIR], check=True)
+            sp.run(['chown', '-R', 'polkadot:polkadot', Path(c.HOME_DIR, Path(docker_specs_path).name)], check=True)
         utils.start_service()
         sp.run(['docker', 'rm', 'tmp'], check=True)
         sp.run(['docker', 'rmi', docker_image_and_tag], check=True)

--- a/src/service_args.py
+++ b/src/service_args.py
@@ -72,7 +72,7 @@ class ServiceArgs():
         elif "--prometheus-port" in service_args:
             msg = "'--prometheus-port' may not be set! Charm assumes default port 9615."
         elif "--node-key-file" in service_args:
-            msg = f'\'--node-key-file\' may not be set! Path is hardcoded to {c.NODE_KEY_PATH}'
+            msg = f'\'--node-key-file\' may not be set! Path is hardcoded to {c.NODE_KEY_PATH_FILE}'
 
         if msg:
             raise ValueError(msg)
@@ -111,7 +111,7 @@ class ServiceArgs():
         self.service_args_list_customized = self.service_args_list_customized + args
 
     def __customize_service_args(self):
-        self.__add_firstchain_args(['--node-key-file', c.NODE_KEY_PATH])
+        self.__add_firstchain_args(['--node-key-file', c.NODE_KEY_PATH_FILE])
         if self._relay_rpc_urls:
             self.__add_firstchain_args(['--relay-chain-rpc-urls'] + list(self._relay_rpc_urls.values()))
 
@@ -156,29 +156,29 @@ class ServiceArgs():
         # The chain spec configs should be applied after hardcoded chain customizations above since this should override any hardcoded --chain overrides.
         if self._chain_spec_url:
             utils.download_chain_spec(self._chain_spec_url, 'chain-spec.json')
-            self.__set_chain_name(f'{c.CHAIN_SPEC_PATH}/chain-spec.json', 0)
+            self.__set_chain_name(f'{c.CHAIN_SPEC_PATH_DIR}/chain-spec.json', 0)
         if self._local_relaychain_spec_url:
             utils.download_chain_spec(self._local_relaychain_spec_url, 'relaychain-spec.json')
-            self.__set_chain_name(f'{c.CHAIN_SPEC_PATH}/relaychain-spec.json', 1)
+            self.__set_chain_name(f'{c.CHAIN_SPEC_PATH_DIR}/relaychain-spec.json', 1)
         if self._runtime_wasm_override:
             self.__add_firstchain_args(['--wasm-runtime-overrides', c.WASM_PATH])
 
     def __peregrine(self):
-        self.__set_chain_name(Path(c.HOME_PATH, 'dev-specs/kilt-parachain/peregrine-kilt.json'), 0)
-        self.__set_chain_name(Path(c.HOME_PATH, 'dev-specs/kilt-parachain/peregrine-relay.json'), 1)
+        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'dev-specs/kilt-parachain/peregrine-kilt.json'), 0)
+        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'dev-specs/kilt-parachain/peregrine-relay.json'), 1)
 
     def __peregrine_stg_kilt(self):
-        self.__set_chain_name(Path(c.HOME_PATH, 'dev-specs/kilt-parachain/peregrine-stg-kilt.json'), 0)
-        self.__set_chain_name(Path(c.HOME_PATH, 'dev-specs/kilt-parachain/peregrine-stg-relay.json'), 1)
+        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'dev-specs/kilt-parachain/peregrine-stg-kilt.json'), 0)
+        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'dev-specs/kilt-parachain/peregrine-stg-relay.json'), 1)
 
     def __peregrine_stg_relay(self):
         utils.download_chain_spec(
             "https://raw.githubusercontent.com/KILTprotocol/kilt-node/1.7.5/dev-specs/kilt-parachain/peregrine-stg-relay.json", "peregrine-stg-relay.json")
-        self.__set_chain_name(Path(c.CHAIN_SPEC_PATH, 'peregrine-stg-relay.json'), 0)
+        self.__set_chain_name(Path(c.CHAIN_SPEC_PATH_DIR, 'peregrine-stg-relay.json'), 0)
 
     def __turing(self):
         chain_json_url = 'https://raw.githubusercontent.com/OAK-Foundation/OAK-blockchain/master/node/res/turing.json'
-        chain_json_path = f"{c.CHAIN_SPEC_PATH}/turing.json"
+        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/turing.json"
         if not exists(chain_json_path):
             utils.download_chain_spec(chain_json_url, 'turing.json')
         self.__set_chain_name(chain_json_path, 0)
@@ -187,7 +187,7 @@ class ServiceArgs():
         # TODO: The spec file did not exist on master branch yet. This URL point to a development branch that will probably not exist in the near future.
         # Update the URL to the master branch when the spec file is merged.
         chain_json_url = 'https://raw.githubusercontent.com/ajuna-network/Ajuna/el/tidy-chain-specs/resources/bajun/bajun-raw.json'
-        chain_json_path = f"{c.CHAIN_SPEC_PATH}/bajun-raw.json"
+        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/bajun-raw.json"
 
         if not exists(chain_json_path):
             utils.download_chain_spec(chain_json_url, 'bajun-raw.json')
@@ -195,13 +195,13 @@ class ServiceArgs():
         self.__set_chain_name(chain_json_path, 0)
 
     def __joystream(self):
-        chain_json_path = f"{c.CHAIN_SPEC_PATH}/joystream.json"
+        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/joystream.json"
         utils.download_chain_spec(
             'https://github.com/Joystream/joystream/releases/download/v11.3.0/joy-testnet-7-carthage.json', 'joystream.json')
         self.__set_chain_name(chain_json_path, 0)
 
     def __equilibrium(self):
-        self.__set_chain_name(Path(c.HOME_PATH, 'chainspec.json'), 0)
+        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'chainspec.json'), 0)
 
     def __aleph_zero(self):
         if self.chain_name.endswith('testnet'):
@@ -221,8 +221,8 @@ class ServiceArgs():
             chain_spec_file_name = 'pendulum.json'
             relay_spec_file_name = 'polkadot.json'
 
-        chain_json_path = f"{c.CHAIN_SPEC_PATH}/{chain_spec_file_name}"
-        relay_json_path = f"{c.CHAIN_SPEC_PATH}/{relay_spec_file_name}"
+        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/{chain_spec_file_name}"
+        relay_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/{relay_spec_file_name}"
 
         if not exists(chain_json_path):
             utils.download_chain_spec(chain_json_url, chain_spec_file_name)
@@ -235,19 +235,19 @@ class ServiceArgs():
 
     def __tinkernet(self):
         chain_json_url = 'https://raw.githubusercontent.com/InvArch/InvArch-Node/main/res/tinker/tinker-raw.json'
-        chain_json_path = f"{c.CHAIN_SPEC_PATH}/tinker-raw.json"
+        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/tinker-raw.json"
 
         utils.download_chain_spec(chain_json_url, 'tinker-raw.json')
         self.__set_chain_name(chain_json_path, 0)
 
     def __clover(self):
-        self.__set_chain_name(Path(c.HOME_PATH, 'specs/clover-para-raw.json'), 0)
+        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'specs/clover-para-raw.json'), 0)
 
     def __polkadex(self):
-        self.__set_chain_name(Path(c.HOME_PATH, 'polkadot-parachain-raw.json'), 0)
+        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'polkadot-parachain-raw.json'), 0)
 
     def __polkadex_mainnet(self):
-        self.__set_chain_name(Path(c.HOME_PATH, 'customSpecRaw.json'), 0)
+        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'customSpecRaw.json'), 0)
 
     def __unique(self):
         if self.chain_name == 'unique':
@@ -257,7 +257,7 @@ class ServiceArgs():
         else:
             raise ValueError("Unsupported chain name.")
 
-        chain_json_path = f'{c.CHAIN_SPEC_PATH}/{self.chain_name}-raw.json'
+        chain_json_path = f'{c.CHAIN_SPEC_PATH_DIR}/{self.chain_name}-raw.json'
 
         utils.download_chain_spec(chain_json_url, f'{self.chain_name}-raw.json')
         self.__set_chain_name(chain_json_path, 0)
@@ -271,22 +271,22 @@ class ServiceArgs():
             self.__set_chain_name('rocky', 0)
 
     def __origintrail(self):
-        if exists(c.BINARY_PATH):
+        if exists(c.BINARY_PATH_FILE):
             chain_json_url = f'https://raw.githubusercontent.com/OriginTrail/origintrail-parachain/v{utils.get_binary_version()}/res/origintrail-parachain-2043-raw.json'
         else:
             chain_json_url = 'https://raw.githubusercontent.com/OriginTrail/origintrail-parachain/develop/res/origintrail-parachain-2043-raw.json'
         utils.download_chain_spec(chain_json_url, f'{self.chain_name}-raw.json')
-        chain_json_path = f'{c.CHAIN_SPEC_PATH}/{self.chain_name}-raw.json'
+        chain_json_path = f'{c.CHAIN_SPEC_PATH_DIR}/{self.chain_name}-raw.json'
         self.__set_chain_name(chain_json_path, 0)
 
     def __asset_hub_rococo(self):
         chain_json_url = 'https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/cumulus/parachains/chain-specs/asset-hub-rococo.json'
-        chain_json_path = f'{c.CHAIN_SPEC_PATH}/{self.chain_name}.json'
+        chain_json_path = f'{c.CHAIN_SPEC_PATH_DIR}/{self.chain_name}.json'
         utils.download_chain_spec(chain_json_url, f'{self.chain_name}.json')
         self.__set_chain_name(chain_json_path, 0)
 
     def __liberland(self):
         chain_json_url = 'https://raw.githubusercontent.com/liberland/liberland_substrate/main/substrate/specs/mainnet.json'
-        chain_json_path = f'{c.CHAIN_SPEC_PATH}/{self.chain_name}.json'
+        chain_json_path = f'{c.CHAIN_SPEC_PATH_DIR}/{self.chain_name}.json'
         utils.download_chain_spec(chain_json_url, f'{self.chain_name}.json')
         self.__set_chain_name(chain_json_path, 0)

--- a/src/service_args.py
+++ b/src/service_args.py
@@ -72,7 +72,7 @@ class ServiceArgs():
         elif "--prometheus-port" in service_args:
             msg = "'--prometheus-port' may not be set! Charm assumes default port 9615."
         elif "--node-key-file" in service_args:
-            msg = f'\'--node-key-file\' may not be set! Path is hardcoded to {c.NODE_KEY_PATH_FILE}'
+            msg = f'\'--node-key-file\' may not be set! Path is hardcoded to {c.NODE_KEY_FILE}'
 
         if msg:
             raise ValueError(msg)
@@ -111,7 +111,7 @@ class ServiceArgs():
         self.service_args_list_customized = self.service_args_list_customized + args
 
     def __customize_service_args(self):
-        self.__add_firstchain_args(['--node-key-file', c.NODE_KEY_PATH_FILE])
+        self.__add_firstchain_args(['--node-key-file', c.NODE_KEY_FILE])
         if self._relay_rpc_urls:
             self.__add_firstchain_args(['--relay-chain-rpc-urls'] + list(self._relay_rpc_urls.values()))
 
@@ -156,12 +156,12 @@ class ServiceArgs():
         # The chain spec configs should be applied after hardcoded chain customizations above since this should override any hardcoded --chain overrides.
         if self._chain_spec_url:
             utils.download_chain_spec(self._chain_spec_url, 'chain-spec.json')
-            self.__set_chain_name(f'{c.CHAIN_SPEC_PATH_DIR}/chain-spec.json', 0)
+            self.__set_chain_name(f'{c.CHAIN_SPEC_DIR}/chain-spec.json', 0)
         if self._local_relaychain_spec_url:
             utils.download_chain_spec(self._local_relaychain_spec_url, 'relaychain-spec.json')
-            self.__set_chain_name(f'{c.CHAIN_SPEC_PATH_DIR}/relaychain-spec.json', 1)
+            self.__set_chain_name(f'{c.CHAIN_SPEC_DIR}/relaychain-spec.json', 1)
         if self._runtime_wasm_override:
-            self.__add_firstchain_args(['--wasm-runtime-overrides', c.WASM_PATH])
+            self.__add_firstchain_args(['--wasm-runtime-overrides', c.WASM_DIR])
 
     def __peregrine(self):
         self.__set_chain_name(Path(c.HOME_DIR, 'dev-specs/kilt-parachain/peregrine-kilt.json'), 0)
@@ -174,11 +174,11 @@ class ServiceArgs():
     def __peregrine_stg_relay(self):
         utils.download_chain_spec(
             "https://raw.githubusercontent.com/KILTprotocol/kilt-node/1.7.5/dev-specs/kilt-parachain/peregrine-stg-relay.json", "peregrine-stg-relay.json")
-        self.__set_chain_name(Path(c.CHAIN_SPEC_PATH_DIR, 'peregrine-stg-relay.json'), 0)
+        self.__set_chain_name(Path(c.CHAIN_SPEC_DIR, 'peregrine-stg-relay.json'), 0)
 
     def __turing(self):
         chain_json_url = 'https://raw.githubusercontent.com/OAK-Foundation/OAK-blockchain/master/node/res/turing.json'
-        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/turing.json"
+        chain_json_path = f"{c.CHAIN_SPEC_DIR}/turing.json"
         if not exists(chain_json_path):
             utils.download_chain_spec(chain_json_url, 'turing.json')
         self.__set_chain_name(chain_json_path, 0)
@@ -187,7 +187,7 @@ class ServiceArgs():
         # TODO: The spec file did not exist on master branch yet. This URL point to a development branch that will probably not exist in the near future.
         # Update the URL to the master branch when the spec file is merged.
         chain_json_url = 'https://raw.githubusercontent.com/ajuna-network/Ajuna/el/tidy-chain-specs/resources/bajun/bajun-raw.json'
-        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/bajun-raw.json"
+        chain_json_path = f"{c.CHAIN_SPEC_DIR}/bajun-raw.json"
 
         if not exists(chain_json_path):
             utils.download_chain_spec(chain_json_url, 'bajun-raw.json')
@@ -195,7 +195,7 @@ class ServiceArgs():
         self.__set_chain_name(chain_json_path, 0)
 
     def __joystream(self):
-        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/joystream.json"
+        chain_json_path = f"{c.CHAIN_SPEC_DIR}/joystream.json"
         utils.download_chain_spec(
             'https://github.com/Joystream/joystream/releases/download/v11.3.0/joy-testnet-7-carthage.json', 'joystream.json')
         self.__set_chain_name(chain_json_path, 0)
@@ -221,8 +221,8 @@ class ServiceArgs():
             chain_spec_file_name = 'pendulum.json'
             relay_spec_file_name = 'polkadot.json'
 
-        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/{chain_spec_file_name}"
-        relay_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/{relay_spec_file_name}"
+        chain_json_path = f"{c.CHAIN_SPEC_DIR}/{chain_spec_file_name}"
+        relay_json_path = f"{c.CHAIN_SPEC_DIR}/{relay_spec_file_name}"
 
         if not exists(chain_json_path):
             utils.download_chain_spec(chain_json_url, chain_spec_file_name)
@@ -235,7 +235,7 @@ class ServiceArgs():
 
     def __tinkernet(self):
         chain_json_url = 'https://raw.githubusercontent.com/InvArch/InvArch-Node/main/res/tinker/tinker-raw.json'
-        chain_json_path = f"{c.CHAIN_SPEC_PATH_DIR}/tinker-raw.json"
+        chain_json_path = f"{c.CHAIN_SPEC_DIR}/tinker-raw.json"
 
         utils.download_chain_spec(chain_json_url, 'tinker-raw.json')
         self.__set_chain_name(chain_json_path, 0)
@@ -257,7 +257,7 @@ class ServiceArgs():
         else:
             raise ValueError("Unsupported chain name.")
 
-        chain_json_path = f'{c.CHAIN_SPEC_PATH_DIR}/{self.chain_name}-raw.json'
+        chain_json_path = f'{c.CHAIN_SPEC_DIR}/{self.chain_name}-raw.json'
 
         utils.download_chain_spec(chain_json_url, f'{self.chain_name}-raw.json')
         self.__set_chain_name(chain_json_path, 0)
@@ -271,22 +271,22 @@ class ServiceArgs():
             self.__set_chain_name('rocky', 0)
 
     def __origintrail(self):
-        if exists(c.BINARY_PATH_FILE):
+        if exists(c.BINARY_FILE):
             chain_json_url = f'https://raw.githubusercontent.com/OriginTrail/origintrail-parachain/v{utils.get_binary_version()}/res/origintrail-parachain-2043-raw.json'
         else:
             chain_json_url = 'https://raw.githubusercontent.com/OriginTrail/origintrail-parachain/develop/res/origintrail-parachain-2043-raw.json'
         utils.download_chain_spec(chain_json_url, f'{self.chain_name}-raw.json')
-        chain_json_path = f'{c.CHAIN_SPEC_PATH_DIR}/{self.chain_name}-raw.json'
+        chain_json_path = f'{c.CHAIN_SPEC_DIR}/{self.chain_name}-raw.json'
         self.__set_chain_name(chain_json_path, 0)
 
     def __asset_hub_rococo(self):
         chain_json_url = 'https://raw.githubusercontent.com/paritytech/polkadot-sdk/master/cumulus/parachains/chain-specs/asset-hub-rococo.json'
-        chain_json_path = f'{c.CHAIN_SPEC_PATH_DIR}/{self.chain_name}.json'
+        chain_json_path = f'{c.CHAIN_SPEC_DIR}/{self.chain_name}.json'
         utils.download_chain_spec(chain_json_url, f'{self.chain_name}.json')
         self.__set_chain_name(chain_json_path, 0)
 
     def __liberland(self):
         chain_json_url = 'https://raw.githubusercontent.com/liberland/liberland_substrate/main/substrate/specs/mainnet.json'
-        chain_json_path = f'{c.CHAIN_SPEC_PATH_DIR}/{self.chain_name}.json'
+        chain_json_path = f'{c.CHAIN_SPEC_DIR}/{self.chain_name}.json'
         utils.download_chain_spec(chain_json_url, f'{self.chain_name}.json')
         self.__set_chain_name(chain_json_path, 0)

--- a/src/service_args.py
+++ b/src/service_args.py
@@ -164,12 +164,12 @@ class ServiceArgs():
             self.__add_firstchain_args(['--wasm-runtime-overrides', c.WASM_PATH])
 
     def __peregrine(self):
-        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'dev-specs/kilt-parachain/peregrine-kilt.json'), 0)
-        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'dev-specs/kilt-parachain/peregrine-relay.json'), 1)
+        self.__set_chain_name(Path(c.HOME_DIR, 'dev-specs/kilt-parachain/peregrine-kilt.json'), 0)
+        self.__set_chain_name(Path(c.HOME_DIR, 'dev-specs/kilt-parachain/peregrine-relay.json'), 1)
 
     def __peregrine_stg_kilt(self):
-        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'dev-specs/kilt-parachain/peregrine-stg-kilt.json'), 0)
-        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'dev-specs/kilt-parachain/peregrine-stg-relay.json'), 1)
+        self.__set_chain_name(Path(c.HOME_DIR, 'dev-specs/kilt-parachain/peregrine-stg-kilt.json'), 0)
+        self.__set_chain_name(Path(c.HOME_DIR, 'dev-specs/kilt-parachain/peregrine-stg-relay.json'), 1)
 
     def __peregrine_stg_relay(self):
         utils.download_chain_spec(
@@ -201,7 +201,7 @@ class ServiceArgs():
         self.__set_chain_name(chain_json_path, 0)
 
     def __equilibrium(self):
-        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'chainspec.json'), 0)
+        self.__set_chain_name(Path(c.HOME_DIR, 'chainspec.json'), 0)
 
     def __aleph_zero(self):
         if self.chain_name.endswith('testnet'):
@@ -241,13 +241,13 @@ class ServiceArgs():
         self.__set_chain_name(chain_json_path, 0)
 
     def __clover(self):
-        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'specs/clover-para-raw.json'), 0)
+        self.__set_chain_name(Path(c.HOME_DIR, 'specs/clover-para-raw.json'), 0)
 
     def __polkadex(self):
-        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'polkadot-parachain-raw.json'), 0)
+        self.__set_chain_name(Path(c.HOME_DIR, 'polkadot-parachain-raw.json'), 0)
 
     def __polkadex_mainnet(self):
-        self.__set_chain_name(Path(c.HOME_PATH_DIR, 'customSpecRaw.json'), 0)
+        self.__set_chain_name(Path(c.HOME_DIR, 'customSpecRaw.json'), 0)
 
     def __unique(self):
         if self.chain_name == 'unique':

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -19,7 +19,7 @@ class Tarball:
                     tarball.extract(member, path=c.HOME_DIR)
                     sp.run(['mv', c.HOME_DIR/'data-avail', c.BINARY_PATH_FILE, '--force'])
                     sp.run(['rm', self.tarball_path])
-                    sp.run(['chown', f'{c.USER_DIR}:{c.USER_DIR}', c.BINARY_PATH_FILE])
+                    sp.run(['chown', f'{c.USER}:{c.USER}', c.BINARY_PATH_FILE])
                 else:
                     raise ValueError("Expected client binary 'data-avail' in tarball is not a file.")
             else:

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -16,8 +16,8 @@ class Tarball:
             if 'data-avail' in tarball.getnames():
                 member = tarball.getmember('data-avail')
                 if member.isfile():
-                    tarball.extract(member, path=c.HOME_PATH_DIR)
-                    sp.run(['mv', c.HOME_PATH_DIR/'data-avail', c.BINARY_PATH_FILE, '--force'])
+                    tarball.extract(member, path=c.HOME_DIR)
+                    sp.run(['mv', c.HOME_DIR/'data-avail', c.BINARY_PATH_FILE, '--force'])
                     sp.run(['rm', self.tarball_path])
                     sp.run(['chown', f'{c.USER_DIR}:{c.USER_DIR}', c.BINARY_PATH_FILE])
                 else:

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -17,9 +17,9 @@ class Tarball:
                 member = tarball.getmember('data-avail')
                 if member.isfile():
                     tarball.extract(member, path=c.HOME_DIR)
-                    sp.run(['mv', c.HOME_DIR/'data-avail', c.BINARY_PATH_FILE, '--force'])
+                    sp.run(['mv', c.HOME_DIR/'data-avail', c.BINARY_FILE, '--force'])
                     sp.run(['rm', self.tarball_path])
-                    sp.run(['chown', f'{c.USER}:{c.USER}', c.BINARY_PATH_FILE])
+                    sp.run(['chown', f'{c.USER}:{c.USER}', c.BINARY_FILE])
                 else:
                     raise ValueError("Expected client binary 'data-avail' in tarball is not a file.")
             else:

--- a/src/tarball.py
+++ b/src/tarball.py
@@ -16,10 +16,10 @@ class Tarball:
             if 'data-avail' in tarball.getnames():
                 member = tarball.getmember('data-avail')
                 if member.isfile():
-                    tarball.extract(member, path=c.HOME_PATH)
-                    sp.run(['mv', c.HOME_PATH/'data-avail', c.BINARY_PATH, '--force'])
+                    tarball.extract(member, path=c.HOME_PATH_DIR)
+                    sp.run(['mv', c.HOME_PATH_DIR/'data-avail', c.BINARY_PATH_FILE, '--force'])
                     sp.run(['rm', self.tarball_path])
-                    sp.run(['chown', f'{c.USER}:{c.USER}', c.BINARY_PATH])
+                    sp.run(['chown', f'{c.USER_DIR}:{c.USER_DIR}', c.BINARY_PATH_FILE])
                 else:
                     raise ValueError("Expected client binary 'data-avail' in tarball is not a file.")
             else:

--- a/src/utils.py
+++ b/src/utils.py
@@ -61,7 +61,7 @@ def find_binary_installed_by_deb(package_name: str, ) -> str:
 
 def install_deb_from_url(url: str) -> None:
     deb_response = requests.get(url, allow_redirects=True, timeout=None)
-    deb_path = Path(c.HOME_PATH_DIR, url.split('/')[-1])
+    deb_path = Path(c.HOME_DIR, url.split('/')[-1])
     with open(deb_path, 'wb') as f:
         f.write(deb_response.content)
     package_name = sp.check_output(['dpkg-deb', '-f', deb_path, 'Package']).decode('utf-8').strip()
@@ -79,7 +79,7 @@ def install_deb_from_url(url: str) -> None:
 
 def install_tarball_from_url(url, sha256_url, chain_name):
     tarball_response = requests.get(url, allow_redirects=True, timeout=None)
-    tarball_path = Path(c.HOME_PATH_DIR, url.split('/')[-1])
+    tarball_path = Path(c.HOME_DIR, url.split('/')[-1])
     if tarball_response.status_code != 200:
         raise ValueError(f"Download binary failed with: {tarball_response.text}. Check 'binary-url'!")
 
@@ -122,7 +122,7 @@ def install_binaries_from_urls(binary_urls: str, sha256_urls: str) -> None:
     stop_service()
     for binary_url, _, response, binary_name, _ in responses:
         logger.debug("Unpack binary downloaded from: %s", binary_url)
-        binary_path = c.HOME_PATH_DIR / binary_name
+        binary_path = c.HOME_DIR / binary_name
         with open(binary_path, 'wb') as f:
             f.write(response.content)
             sp.run(['chown', f'{c.USER_DIR}:{c.USER_DIR}', binary_path], check=False)
@@ -241,9 +241,9 @@ def download_file(url: str, filepath: Path) -> None:
 
 def setup_group_and_user():
     sp.run(['addgroup', '--system', c.USER_DIR], check=False)
-    sp.run(['adduser', '--system', '--home', c.HOME_PATH_DIR, '--disabled-password', '--ingroup', c.USER_DIR, c.USER_DIR], check=False)
-    sp.run(['chown', f'{c.USER_DIR}:{c.USER_DIR}', c.HOME_PATH_DIR], check=False)
-    sp.run(['chmod', '700', c.HOME_PATH_DIR], check=False)
+    sp.run(['adduser', '--system', '--home', c.HOME_DIR, '--disabled-password', '--ingroup', c.USER_DIR, c.USER_DIR], check=False)
+    sp.run(['chown', f'{c.USER_DIR}:{c.USER_DIR}', c.HOME_DIR], check=False)
+    sp.run(['chmod', '700', c.HOME_DIR], check=False)
 
 
 def create_env_file_for_service():

--- a/src/utils.py
+++ b/src/utils.py
@@ -70,9 +70,9 @@ def install_deb_from_url(url: str) -> None:
     sp.check_call(['dpkg', '--purge', package_name])
     sp.check_call(['dpkg', '--install', deb_path])
     installed_binary = find_binary_installed_by_deb(package_name)
-    if os.path.exists(c.BINARY_PATH_FILE):
-        os.remove(c.BINARY_PATH_FILE)
-    os.symlink(installed_binary, c.BINARY_PATH_FILE)
+    if os.path.exists(c.BINARY_FILE):
+        os.remove(c.BINARY_FILE)
+    os.symlink(installed_binary, c.BINARY_FILE)
     start_service()
     os.remove(deb_path)
 
@@ -140,10 +140,10 @@ def install_binary_from_url(url: str, sha256_url: str) -> None:
         binary_hash = hashlib.sha256(binary_response.content).hexdigest()
         perform_sha256_checksum(binary_hash, sha256_url)
     stop_service()
-    with open(c.BINARY_PATH_FILE, 'wb') as f:
+    with open(c.BINARY_FILE, 'wb') as f:
         f.write(binary_response.content)
-        sp.run(['chown', f'{c.USER}:{c.USER}', c.BINARY_PATH_FILE], check=False)
-        sp.run(['chmod', '+x', c.BINARY_PATH_FILE], check=False)
+        sp.run(['chown', f'{c.USER}:{c.USER}', c.BINARY_FILE], check=False)
+        sp.run(['chmod', '+x', c.BINARY_FILE], check=False)
     start_service()
 
 
@@ -188,10 +188,10 @@ def get_sha256_response(sha256_url: str) -> requests.Response:
 
 def download_chain_spec(url: str, filename: Path) -> None:
     """Download a chain spec file from a given URL to a given filepath."""
-    if not c.CHAIN_SPEC_PATH_DIR.exists():
-        c.CHAIN_SPEC_PATH_DIR.mkdir(parents=True)
+    if not c.CHAIN_SPEC_DIR.exists():
+        c.CHAIN_SPEC_DIR.mkdir(parents=True)
     try:
-        download_file(url, Path(c.CHAIN_SPEC_PATH_DIR, filename))
+        download_file(url, Path(c.CHAIN_SPEC_DIR, filename))
     except ValueError as e:
         logger.error(f'Failed to download chain spec: {e}')
         raise e
@@ -204,8 +204,8 @@ def download_wasm_runtime(url):
     filename = Path(url.split('/')[-1])
     if not filename.name.endswith('.tar.gz') and not filename.suffix == '.wasm':
         raise ValueError(f'Invalid file format provided for wasm-runtime-url: {filename.name}')
-    if not c.WASM_PATH.exists():
-        c.WASM_PATH.mkdir(parents=True)
+    if not c.WASM_DIR.exists():
+        c.WASM_DIR.mkdir(parents=True)
     with tempfile.TemporaryDirectory() as temp_dir:
         try:
             download_file(url, Path(temp_dir, filename))
@@ -217,15 +217,15 @@ def download_wasm_runtime(url):
             tarball.extractall(temp_dir)
             tarball.close()
         stop_service()
-        files = glob.glob(f'{c.WASM_PATH}/*.wasm')
+        files = glob.glob(f'{c.WASM_DIR}/*.wasm')
         for f in files:
             os.remove(f)
         files_in_temp_dir = glob.glob(f'{temp_dir}/*')
         logger.debug('Files in temp_dir: %s', str(files_in_temp_dir))
         wasm_files = glob.glob(f'{temp_dir}/*.wasm')
         for wasm_file in wasm_files:
-            shutil.move(wasm_file, c.WASM_PATH)
-    sp.run(['chown', '-R', f'{c.USER}:{c.USER}', c.WASM_PATH], check=False)
+            shutil.move(wasm_file, c.WASM_DIR)
+    sp.run(['chown', '-R', f'{c.USER}:{c.USER}', c.WASM_DIR], check=False)
 
 
 def download_file(url: str, filepath: Path) -> None:
@@ -279,9 +279,9 @@ def install_node_exporter():
 def get_binary_version() -> str:
     """ Returns the version of the binary client by checking the '--version' flag. """
     logger.debug("Getting binary version from client binary.")
-    if c.BINARY_PATH_FILE.exists():
+    if c.BINARY_FILE.exists():
         try:
-            command = [c.BINARY_PATH_FILE, "--version"]
+            command = [c.BINARY_FILE, "--version"]
             output = sp.run(command, stdout=sp.PIPE, check=False).stdout.decode('utf-8').strip()
             version = re.search(r'([\d.]+)', output).group(1)
             return version
@@ -291,16 +291,16 @@ def get_binary_version() -> str:
 
 
 def get_binary_md5sum() -> str:
-    if c.BINARY_PATH_FILE.exists():
-        command = ['md5sum', c.BINARY_PATH_FILE]
+    if c.BINARY_FILE.exists():
+        command = ['md5sum', c.BINARY_FILE]
         md5sum_output = sp.run(command, stdout=sp.PIPE, check=False).stdout.decode('utf-8').strip()
         return md5sum_output.split(' ')[0]  # Output includes path of binary, which we skip including
     return ""
 
 
 def get_binary_last_changed() -> str:
-    if c.BINARY_PATH_FILE.exists():
-        command = ['stat', c.BINARY_PATH_FILE]
+    if c.BINARY_FILE.exists():
+        command = ['stat', c.BINARY_FILE]
         stat_output = sp.run(command, stdout=sp.PIPE, check=False).stdout.decode('utf-8').strip()
         stat_split = re.split('Change: ', stat_output)[1].split(' ')
         date = stat_split[0]
@@ -315,8 +315,8 @@ def restart_service():
 
 def start_service():
     # TODO: remove chown and chmod from here? Runs in the install hook already
-    sp.run(['chown', f'{c.USER}:{c.USER}', c.BINARY_PATH_FILE], check=False)
-    sp.run(['chmod', '+x', c.BINARY_PATH_FILE], check=False)
+    sp.run(['chown', f'{c.USER}:{c.USER}', c.BINARY_FILE], check=False)
+    sp.run(['chmod', '+x', c.BINARY_FILE], check=False)
     sp.run(['systemctl', 'start', f'{c.USER}.service'], check=False)
 
 
@@ -335,10 +335,10 @@ def service_started(iterations: int = 6) -> bool:
 
 
 def write_node_key_file(key):
-    with open(c.NODE_KEY_PATH_FILE, "w", encoding='utf-8') as f:
+    with open(c.NODE_KEY_FILE, "w", encoding='utf-8') as f:
         f.write(key)
-    sp.run(['chown', f'{c.USER}:{c.USER}', c.NODE_KEY_PATH_FILE], check=False)
-    sp.run(['chmod', '0600', c.NODE_KEY_PATH_FILE], check=False)
+    sp.run(['chown', f'{c.USER}:{c.USER}', c.NODE_KEY_FILE], check=False)
+    sp.run(['chmod', '0600', c.NODE_KEY_FILE], check=False)
 
 
 def get_disk_usage(path: Path) -> str:
@@ -355,14 +355,14 @@ def get_disk_usage(path: Path) -> str:
 
 
 def get_chain_disk_usage() -> str:
-    if c.DB_CHAIN_PATH_DIR.exists():
-        return get_disk_usage(c.DB_CHAIN_PATH_DIR)
+    if c.DB_CHAIN_DIR.exists():
+        return get_disk_usage(c.DB_CHAIN_DIR)
     return ""
 
 
 def get_relay_disk_usage() -> str:
-    if c.DB_RELAY_PATH_DIR.exists():
-        return get_disk_usage(c.DB_RELAY_PATH_DIR)
+    if c.DB_RELAY_DIR.exists():
+        return get_disk_usage(c.DB_RELAY_DIR)
     return ""
 
 
@@ -394,10 +394,10 @@ def is_relay_chain_node() -> bool:
 
 def is_parachain_node() -> bool:
     # TODO: should both of these be required to satisfy the node being a parachain, or is one enough?
-    if c.DB_CHAIN_PATH_DIR.exists() and c.DB_RELAY_PATH_DIR.exists():
+    if c.DB_CHAIN_DIR.exists() and c.DB_RELAY_DIR.exists():
         return True
-    if c.BINARY_PATH_FILE.exists():
-        command = f'.{c.BINARY_PATH_FILE} --help | grep -i "\-\-collator"'
+    if c.BINARY_FILE.exists():
+        command = f'.{c.BINARY_FILE} --help | grep -i "\-\-collator"'
         output = sp.run(command, stdout=sp.PIPE, cwd='/', shell=True, check=False)
         if output.returncode == 0:
             return True
@@ -408,7 +408,7 @@ def get_relay_for_parachain() -> str:
     if not is_parachain_node():
         return 'Error, this is not a parachain'
     try:
-        chains_dir = Path(c.DB_RELAY_PATH_DIR, 'chains')
+        chains_dir = Path(c.DB_RELAY_DIR, 'chains')
         chains_subdirs = [d for d in chains_dir.iterdir() if d.is_dir()]
         if len(chains_subdirs) == 1:
             db_dir = str(chains_subdirs[0])
@@ -427,8 +427,8 @@ def get_relay_for_parachain() -> str:
 
 
 def get_wasm_info() -> str:
-    if c.WASM_PATH.exists():
-        files = list(c.WASM_PATH.glob('*.wasm'))
+    if c.WASM_DIR.exists():
+        files = list(c.WASM_DIR.glob('*.wasm'))
         if not files:
             return "No wasm files found in ~/wasm directory"
         files = [str(f.name) for f in files]
@@ -437,8 +437,8 @@ def get_wasm_info() -> str:
 
 
 def get_client_binary_help_output() -> str:
-    if c.BINARY_PATH_FILE.exists():
-        command = f'.{c.BINARY_PATH_FILE} --help'
+    if c.BINARY_FILE.exists():
+        command = f'.{c.BINARY_FILE} --help'
         process = sp.run(command, stdout=sp.PIPE, cwd='/', shell=True, check=False)
         if process.returncode == 0:
             return process.stdout.decode('utf-8').strip()


### PR DESCRIPTION
### Description:
Constants in the constants.py should be named after what they represent e.g. `_DIR` for directories and `_FILE` for files.

### Testing Screenshots:
![jujustatus](https://github.com/dwellir-public/polkadot-operator/assets/116648836/70664d63-9201-4522-bd93-6d072b5b642b)

![logs](https://github.com/dwellir-public/polkadot-operator/assets/116648836/3f876023-c509-4675-9007-9e64d0c472bf)


![image](https://github.com/dwellir-public/polkadot-operator/assets/116648836/20343bb7-c2a9-443c-b7c6-f77b2e56badd)

