### PR TITLE
Remove the ending dot when printing validator address.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -261,7 +261,7 @@ class PolkadotCharm(ops.CharmBase):
         rpc_port = ServiceArgs(self.config, self.rpc_urls()).rpc_port
         result = PolkadotRpcWrapper(rpc_port).is_validating_this_era()
         if result:
-            event.set_results(results={'message': f'This node is currently validating for address {result["validator"]}.'})
+            event.set_results(results={'message': f'This node is currently validating for address {result["validator"]}'})
             event.set_results(results={'session-key': result["session_key"]})
         else:
             event.set_results(results={'message': 'This node is not currently validating for any address.'})
@@ -272,10 +272,10 @@ class PolkadotCharm(ops.CharmBase):
         rpc_port = ServiceArgs(self.config, self.rpc_urls()).rpc_port
         session_key = PolkadotRpcWrapper(rpc_port).is_validating_next_era(validator_address)
         if session_key:
-            event.set_results(results={'message': f'This node will be validating next era for address {validator_address}.'})
+            event.set_results(results={'message': f'This node will be validating next era for address {validator_address}'})
             event.set_results(results={'session-key': session_key})
         else:
-            event.set_results(results={'message': f'This node will not be validating next era for address {validator_address}.'})
+            event.set_results(results={'message': f'This node will not be validating next era for address {validator_address}'})
 
     # TODO: this action is getting quite large and specialized, perhaps move all actions to an `actions.py` file?
     def _on_get_node_info_action(self, event: ops.ActionEvent) -> None:


### PR DESCRIPTION
I got tired of always having to remove the dot from the address when double-click-copying it.