### PR TITLE
print the session key splitted for convenience

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -204,7 +204,17 @@ class PolkadotCharm(ops.CharmBase):
         rpc_port = ServiceArgs(self.config, self.rpc_urls()).rpc_port
         key = PolkadotRpcWrapper(rpc_port).get_session_key()
         if key:
-            event.set_results(results={'session-key': key})
+            event.set_results(results={'session-keys-merged': key})
+
+            # For convenience, also print a splitted version of the session key
+            # Remove the initial '0x'
+            key_without_prefix = key[2:]
+            # Split the key into chunks of 64 characters
+            chunks = [key_without_prefix[i:i+64] for i in range(0, len(key_without_prefix), 64)]
+            # Add '0x' to each chunk
+            keys_with_prefix = [f"0x{chunk}" for chunk in chunks]
+            for i, key in enumerate(keys_with_prefix):
+                event.set_results(results={f'session-key-{i}': key})
         else:
             event.fail("Unable to get new session key")
 


### PR DESCRIPTION
Sometimes (e.g. enjin) one needs to enter the session keys separately. I have manually split it every time. This saves some time.
Example result from the action:
```
session-key-0: 0xef6109abc7fce16e585cc2e1feb2a005324d3ddec89a1a3e5f42b39c84563827
session-key-1: 0xbac5d1409d3fff746003b7226573d2877356325bff70aea8322a69d7f04e6f69
session-key-2: 0xfe8877a235e06d818d8381f3e2d2c0e915d3e65cbc9cc23f261c6d189bdc1c16
session-key-3: 0xfa41478f2c31d3421a22ab8270a8449b943ba7df996f3cfb56d7061a8d652a0a
session-key-4: 0x2a774692c397178238492ca32f985325cc8965b89cbd6d15ded1bd1c035ef801
session-keys-merged: 0xef6109abc7fce16e585cc2e1feb2a005324d3ddec89a1a3e5f42b39c84563827bac5d1409d3fff746003b7226573d2877356325bff70aea8322a69d7f04e6f69fe8877a235e06d818d8381f3e2d2c0e915d3e65cbc9cc23f261c6d189bdc1c16fa41478f2c31d3421a22ab8270a8449b943ba7df996f3cfb56d7061a8d652a0a2a774692c397178238492ca32f985325cc8965b89cbd6d15ded1bd1c035ef801
```