### PR TITLE
Use the original names for spec files when downloading

### DIFF
--- a/src/service_args.py
+++ b/src/service_args.py
@@ -3,7 +3,7 @@
 import constants as c
 import utils
 from pathlib import Path
-from os.path import exists
+import os
 import re
 from ops.model import ConfigData
 
@@ -123,11 +123,13 @@ class ServiceArgs():
 
         # The chain spec configs should be applied after hardcoded chain customizations above since this should override any hardcoded --chain overrides.
         if self._chain_spec_url:
-            utils.download_chain_spec(self._chain_spec_url, 'chain-spec.json')
-            self.__set_chain_name(f'{c.CHAIN_SPEC_DIR}/chain-spec.json', 0)
+            file_name = os.path.basename(self._chain_spec_url)
+            utils.download_chain_spec(self._chain_spec_url, file_name)
+            self.__set_chain_name(f'{c.CHAIN_SPEC_DIR}/{file_name}', 0)
         if self._local_relaychain_spec_url:
-            utils.download_chain_spec(self._local_relaychain_spec_url, 'relaychain-spec.json')
-            self.__set_chain_name(f'{c.CHAIN_SPEC_DIR}/relaychain-spec.json', 1)
+            file_name = os.path.basename(self._local_relaychain_spec_url)
+            utils.download_chain_spec(self._local_relaychain_spec_url, file_name)
+            self.__set_chain_name(f'{c.CHAIN_SPEC_DIR}/{file_name}', 1)
         if self._runtime_wasm_override:
             self.__add_firstchain_args(['--wasm-runtime-overrides', c.WASM_DIR])
 


### PR DESCRIPTION
What would you say about not renaming the files at all? Instead of adding an ugly customization for kilt.