### PR TITLE
Prevent unnecessary restarts from relation-changed hooks

### DIFF
--- a/src/interface_rpc_url_requirer.py
+++ b/src/interface_rpc_url_requirer.py
@@ -33,6 +33,7 @@ class RpcUrlRequirer(Object):
         """
         Update service args in response to a change in the relation data.
         """
-        service_args_obj = ServiceArgs(self._charm.config, self._charm.rpc_urls())
-        utils.update_service_args(service_args_obj.service_args_string)
+        argument_string = ServiceArgs(self._charm.config, self._charm.rpc_urls()).service_args_string
+        if utils.arguments_differ_from_disk(argument_string):
+            utils.update_service_args(argument_string)
         self._charm.update_status()

--- a/src/utils.py
+++ b/src/utils.py
@@ -274,12 +274,20 @@ def install_service_file(source_path):
     shutil.copyfile(source_path, target_path)
     sp.run(['systemctl', 'daemon-reload'], check=False)
 
+def render_service_argument_file(service_args):
+    return f"{c.USER.upper()}_CLI_ARGS='{service_args}'\n"
 
+def arguments_differ_from_disk(service_args):
+    try:
+        with open(f'/etc/default/{c.USER}', 'r', encoding='utf-8') as f:
+            args = f.read()
+        return args != render_service_argument_file(service_args)
+    except FileNotFoundError:
+        return True
+    
 def update_service_args(service_args):
-    args = f"{c.USER.upper()}_CLI_ARGS='{service_args}'"
-
     with open(f'/etc/default/{c.USER}', 'w', encoding='utf-8') as f:
-        f.write(args + '\n')
+        f.write(render_service_argument_file(service_args))
     sp.run(['systemctl', 'restart', f'{c.USER}.service'], check=False)
 
 


### PR DESCRIPTION
When migrating Juju models such as during a controller upgrade, relation-changed hooks are triggered whether anything has changed or not. This causes service disruptions and makes the upgrade process needlessly cumbersome. This PR introduces a small change that checks to make sure that the event handler would actually change the on disk configuration before it attempts to reconfigure the node.