### PR TITLE
Fix build workflow (#93)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,13 +8,15 @@ on:
 jobs:
   build:
     name: Build Polkadot charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v26.0.1
+    with:
+      charmcraft-snap-revision: 5780
 
   release:
     name: Release charm
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v26.0.1
     with:
       channel: latest/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,20 +1,8 @@
 type: charm
-bases:
-  - build-on:
-      - name: ubuntu
-        channel: "20.04"
-    run-on:
-      - name: ubuntu
-        channel: "20.04"
-        architectures: [amd64]
-  - build-on:
-      - name: ubuntu
-        channel: "22.04"
-    run-on:
-      - name: ubuntu
-        channel: "22.04"
-        architectures: [amd64]
 
+platforms:
+  ubuntu@20.04:amd64:
+  ubuntu@22.04:amd64:
 
 # This below is needed for charmhelpers 0.20.24 to build
 parts:


### PR DESCRIPTION
* Update data-platform-workflows to v26.0.0 (#92)

* tmp: only run build job and for this branch. REMOVE BEFORE MAIN

* Using the new platforms keyword for charmcraft 3.3.0

* bumped data-platform-workflows to 26.0.1 and set charmcraft version to 3.3.0

* setting channel instead of revision for charmcraft

* Using short hand notation for platforms to be compatible with data-platform-workflows

* Trying setting revision again for charmcraft

* using revision number instead of version number

* Added the release job again and set main branch

---------