### PR TITLE
Fix: Config change should not auto start the workload

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -80,7 +80,8 @@ class PolkadotCharm(ops.CharmBase):
                                  snap_hold=self.config.get('snap-hold'),
                                  snap_endure=self.config.get('snap-endure'),
                                  snap_revision=self.config.get('snap-revision'),
-                                 snap_channel=self.config.get('snap-channel')
+                                 snap_channel=self.config.get('snap-channel'),
+                                 service_init=True
                                  )
 
     def rpc_urls(self):
@@ -182,7 +183,12 @@ class PolkadotCharm(ops.CharmBase):
                 self.unit.status = ops.BlockedStatus(str(e))
                 event.defer()
                 return
-
+        
+        # Start the service if it was just initialized
+        if self._stored.service_init:
+            utils.start_service()
+            self._stored.service_init = False
+        
         self.update_status_simple()
 
     def _on_update_status(self, event: ops.UpdateStatusEvent) -> None:


### PR DESCRIPTION
Config change on binary url or docker tag or snap would auto start the workload if it is in a stopped state.
This MR would cause the workload to restart only if it is already in a running state otherwise the only binary or snap would be updated and the start would have to be triggered via the run command.