### PR TITLE
Fix cmdline to work in binary mode

### DIFF
--- a/src/core/utils/general_util.py
+++ b/src/core/utils/general_util.py
@@ -50,7 +50,7 @@ def get_binary_last_changed(binary_path: Union[Path, str]) -> str:
     return ""
 
 def get_process_id(process_name: str) -> str:
-    command = ['pgrep', f'{process_name}']
+    command = ['pgrep', '-x', f'{process_name}']
     pgrep_output = sp.run(command, stdout=sp.PIPE, check=False).stdout.decode('utf-8').strip()
     return pgrep_output
 


### PR DESCRIPTION
I found out that there are substrate nodes where cmdline is not collected correctly
The charm is doing `pgrep polkadot` but there can be multiple processes containing that string, e.g.:
```
polkadot    2222  0.0 10.9 554965500 3407508 ?   Ssl  Feb06 5793:27 /home/polkadot/polkadot --node-key-file /home/polkadot/node-key --port 30375 --public-addr /ip4/79.136.114.244/tcp/30375 --rpc-port 9933 --chain /home/polkadot/spec/chain-spec.json -
root        2498  0.0  0.1 603644 36608 ?        Ssl  Feb06  17:30 /opt/fluent-bit/bin/fluent-bit -c //etc/fluent-bit/fluent-bit.conf
polkadot    2518  0.0  0.0 418396  9376 ?        S    Feb06 335:54 /home/polkadot/polkadot-execute-worker execute-worker --node-impl-version 1.21.1 --socket-path /tmp/pvf-host-execute-BeTdqfnB1c --worker-dir-path /home/polkadot/.local/share/polkadot/
polkadot    2519  0.0  0.0 428632  8928 ?        S    Feb06  86:45 /home/polkadot/polkadot-execute-worker execute-worker --node-impl-version 1.21.1 --socket-path /tmp/pvf-host-execute-Y5kwAixNXT --worker-dir-path /home/polkadot/.local/share/polkadot/
polkadot    2520  0.0  0.0 391768  8800 ?        S    Feb06  22:16 /home/polkadot/polkadot-execute-worker execute-worker --node-impl-version 1.21.1 --socket-path /tmp/pvf-host-execute-jIeQD935Gn --worker-dir-path /home/polkadot/.local/share/polkadot/
polkadot    2691  0.0  0.0 612188 21352 ?        S    Feb06   0:07 /home/polkadot/polkadot-prepare-worker prepare-worker --node-impl-version 1.21.1 --socket-path /tmp/pvf-host-prepare-kxyl7P91aV --worker-dir-path /home/polkadot/.local/share/polkadot/
polkadot    2957  0.0  0.0 331356  9932 ?        S    Feb06   5:25 /home/polkadot/polkadot-execute-worker execute-worker --node-impl-version 1.21.1 --socket-path /tmp/pvf-host-execute-77kX2mAHer --worker-dir-path /home/polkadot/.local/share/polkadot/
```
so the `proc_id` in the code would become '2222\n2518\n2519\n2520\n2691\n2957' and of course fail.

Adding `-x` ...
` -x, --exact               match exactly with the command name`
seems to solve this. I have tried with both a binary and snap node.