### PR TITLE
Fix: config changes not triggering service restart

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -334,8 +334,10 @@ class PolkadotCharm(ops.CharmBase):
                     return
 
         self._workload.set_service_args(service_args_obj.service_args_string)
-        # Start the service if it was just initialized or restart is required due to config changes
-        if self._stored.service_init or should_restart:
+        # Restart the service if it was running before config changes, or start it if just initialized
+        if should_restart:
+            self._workload.restart_service()
+        elif self._stored.service_init:
             self._workload.start_service()
 
         self.update_status_simple()


### PR DESCRIPTION
Changing service-args, binary-url, or docker-tag config values was not triggering a service restart, meaning the running node continued with the old arguments or old binary until manually restarted.                                                                
                                                                                           
**Root cause**: _on_config_changed called start_service() (systemctl start) even when the service was already running. systemctl start is a no-op on a running service, so config changes took effect on disk but were never picked up by the live process.

**Fix**: When the service was running before the config change (should_restart=True), call restart_service() (systemctl restart) instead. start_service() is now only used for initial bring-up when the service has never been started.