### PR TITLE
Publish relation addresses from bind_address instead of ingress-address

### DIFF
--- a/src/interface_prometheus.py
+++ b/src/interface_prometheus.py
@@ -1,10 +1,11 @@
 #!/usr/bin/python3
 """prometheus scrape interface (provides side)."""
 
-from ops.framework import Object
+import hashlib
 import json
-import socket
-from uuid import uuid4
+
+from ops.framework import Object
+
 
 class PrometheusProvider(Object):
     """Prometheus  provider interface."""
@@ -17,8 +18,12 @@ class PrometheusProvider(Object):
         valid keys in the prometheus configuration files.
         """
         super().__init__(charm, relation_name)
+        self._relation_name = relation_name
+        request_id = hashlib.sha256(
+            f"{self.model.uuid}:{relation_name}:{self.model.unit.name}".encode()
+        ).hexdigest()
         self.job = {
-            "job_name": f'{socket.gethostname()}_{self.model.name}_{relation_name}_uuid-{uuid4()}',
+            "job_name": f"{relation_name}",
             "job_data": {
                 "honor_timestamps": True,
                 "scrape_interval": "15s",
@@ -29,17 +34,14 @@ class PrometheusProvider(Object):
                 "enable_http2": True,
                 **job_data,
                 },
-            "request_id": str(uuid4())[-6:],
+            "request_id": request_id,
             "port": str(port),
         }
         # NOTE
-        # request_id must be unique for every relation and unit in the current model, hence the use of UUID.
+        # request_id must be unique for every relation and unit in the current model.
         # job_name in Prometheus will become (job_name + "-" + request_id). Note the dash between those two variables that will be automatically added by the Prometheus charm.
-        # Example of a resulting job_name in Prometheus: dwellir-westend-rpc-1_juju-a4c6ea-0_node-prometheus-d95f1796-f317-457a-b730-c3de4f72b8ff-68916a
-        #
-        # Prometheus charm assumes job_name ends with an UUID so we need to have one there as well.
-        # See: https://git.launchpad.net/charm-prometheus2/commit/?id=26c4a20163a7d655bb1e0e5e925114e57bf16b4a
-        
+        # Example of a resulting job_name in Prometheus: polkadot-prometheus-<request-id>
+
         self.framework.observe(
             charm.on[relation_name].relation_joined, self._on_relation_joined
         )
@@ -50,7 +52,18 @@ class PrometheusProvider(Object):
         :param event:
         :return:
         """
-        ingress_address = event.relation.data.get(self.model.unit)['ingress-address']
-        if "static_configs" not in self.job["job_data"]:
-            self.job["job_data"]["static_configs"] = [{"targets": [f"{ingress_address}:{self.job['port']}"]}]
-        event.relation.data[self.model.unit][f'request_{self.job["request_id"]}'] = json.dumps(self.job, sort_keys=True)
+        bind_address = getattr(
+            self.model.get_binding(self._relation_name).network,
+            "bind_address",
+            None,
+        )
+        if not bind_address:
+            event.defer()
+            return
+
+        self.job["job_data"]["static_configs"] = [
+            {"targets": [f"{bind_address}:{self.job['port']}"]}
+        ]
+        event.relation.data[self.model.unit][
+            f'request_{self.job["request_id"]}'
+        ] = json.dumps(self.job, sort_keys=True)

--- a/src/interface_prometheus.py
+++ b/src/interface_prometheus.py
@@ -1,69 +1,101 @@
 #!/usr/bin/python3
-"""prometheus scrape interface (provides side)."""
+"""Prometheus manual jobs provider."""
 
 import hashlib
 import json
+import socket
 
 from ops.framework import Object
 
 
 class PrometheusProvider(Object):
-    """Prometheus  provider interface."""
+    """Publish manual scrape jobs to prometheus2."""
 
-    def __init__(self, charm, relation_name, port, path, **job_data):
+    def __init__(self, charm, relation_name, port, path, job_name=None, **job_data):
         """
-        Attaches a dictionary containing job data. If you wish to overwrite
-        individual fields like "honor_timestamps", you can add your own value
-        for it as a keyword argument. Just make sure all keyword arguments are
-        valid keys in the prometheus configuration files.
+        Configure a prometheus-manual job publisher.
+
+        If you wish to overwrite individual fields like
+        "honor_timestamps", you can add your own value for it as a keyword
+        argument. Just make sure all keyword arguments are valid keys in the
+        Prometheus configuration files.
         """
         super().__init__(charm, relation_name)
         self._relation_name = relation_name
-        request_id = hashlib.sha256(
+        self._job_name = job_name or relation_name
+        self._path = path
+        self._port = str(port)
+        self._job_data = job_data
+        self._request_id = hashlib.sha1(
             f"{self.model.uuid}:{relation_name}:{self.model.unit.name}".encode()
-        ).hexdigest()
-        self.job = {
-            "job_name": f"{relation_name}",
-            "job_data": {
-                "honor_timestamps": True,
-                "scrape_interval": "15s",
-                "scrape_timeout": "15s",
-                "metrics_path": path,
-                "scheme": "http",
-                "follow_redirects": True,
-                "enable_http2": True,
-                **job_data,
-                },
-            "request_id": request_id,
-            "port": str(port),
-        }
-        # NOTE
-        # request_id must be unique for every relation and unit in the current model.
-        # job_name in Prometheus will become (job_name + "-" + request_id). Note the dash between those two variables that will be automatically added by the Prometheus charm.
-        # Example of a resulting job_name in Prometheus: polkadot-prometheus-<request-id>
+        ).hexdigest()[:8]
 
         self.framework.observe(
             charm.on[relation_name].relation_joined, self._on_relation_joined
         )
 
     def _on_relation_joined(self, event):
-        """We use this event for passing on hostname and port and metrics_path.
+        """Publish the manual scrape job when related."""
+        self.set_job(event)
 
-        :param event:
-        :return:
-        """
+    def _job(self, bind_address):
+        """Build the manual scrape job payload."""
+        job_name_prefix = "-".join(
+            part
+            for part in (
+                self.model.name,
+                self.model.app.name,
+                self.model.unit.name.replace("/", "-"),
+                self._job_name,
+            )
+            if part
+        )
+        labels = {
+            "juju_model": self.model.name,
+            "juju_model_uuid": self.model.uuid,
+            "juju_application": self.model.app.name,
+            "juju_unit": self.model.unit.name,
+            "hostname": socket.gethostname(),
+        }
+
+        # prometheus2 strips the last five dash-delimited segments when
+        # deduplicating manual jobs, so keep the meaningful identifier before
+        # this short suffix.
+        dedupe_suffix = "x-x-x-x"
+        return {
+            "job_name": f"{job_name_prefix}-{dedupe_suffix}",
+            "job_data": {
+                "honor_timestamps": True,
+                "scrape_interval": "15s",
+                "scrape_timeout": "15s",
+                "metrics_path": self._path,
+                "scheme": "http",
+                "follow_redirects": True,
+                "enable_http2": True,
+                "static_configs": [
+                    {
+                        "targets": [f"{bind_address}:{self._port}"],
+                        "labels": labels,
+                    }
+                ],
+                **self._job_data,
+            },
+            "request_id": self._request_id,
+            "port": self._port,
+        }
+
+    def set_job(self, event=None):
+        """Publish the current scrape job to all related consumers."""
         bind_address = getattr(
             self.model.get_binding(self._relation_name).network,
             "bind_address",
             None,
         )
         if not bind_address:
-            event.defer()
+            if event:
+                event.defer()
             return
 
-        self.job["job_data"]["static_configs"] = [
-            {"targets": [f"{bind_address}:{self.job['port']}"]}
-        ]
-        event.relation.data[self.model.unit][
-            f'request_{self.job["request_id"]}'
-        ] = json.dumps(self.job, sort_keys=True)
+        job = json.dumps(self._job(str(bind_address)), sort_keys=True)
+        for relation in self.model.relations[self._relation_name]:
+            relation.data[self.model.unit][f"request_{self._request_id}"] = job

--- a/src/interface_rpc_url_provider.py
+++ b/src/interface_rpc_url_provider.py
@@ -11,6 +11,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+
 class RpcUrlProvider(Object):
     """
     RPC URL provider interface.
@@ -30,6 +31,14 @@ class RpcUrlProvider(Object):
         """This event is used to broadcast the rpc url to the parachain clients."""
 
         service_args_obj = ServiceArgs(self._charm.config, "")
+        bind_address = getattr(
+            self.model.get_binding(self._relation_name).network,
+            "bind_address",
+            None,
+        )
+        if not bind_address:
+            event.defer()
+            return
 
         ws_port = service_args_obj.ws_port
         rpc_port = service_args_obj.rpc_port
@@ -47,8 +56,7 @@ class RpcUrlProvider(Object):
             logger.info(f'Using same RPC port ({rpc_port}) for websocket and http due to newer version of Polkadot.')
             ws_port = rpc_port
         
-        ingress_address = event.relation.data.get(self.model.unit)['ingress-address']
         if rpc_port:
-            event.relation.data[self.model.unit]['rpc_url'] = f'http://{ingress_address}:{rpc_port}'
+            event.relation.data[self.model.unit]['rpc_url'] = f'http://{bind_address}:{rpc_port}'
         if ws_port:
-            event.relation.data[self.model.unit]['ws_url'] = f'ws://{ingress_address}:{ws_port}'
+            event.relation.data[self.model.unit]['ws_url'] = f'ws://{bind_address}:{ws_port}'


### PR DESCRIPTION
Already implemented in our reth charm. See https://github.com/dwellir-public/ops/pull/607 for more information.

ADD: since we are using one central prometheus in US, I made job-names more unique to support that. Added som nice to have extra labels as well.