### PR TITLE
Support multiple deploys on the same machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository is maintained by Dwellir, https://dwellir.com - Infrastructure p
 
 [Polkadot](https://polkadot.network/) is a web3 blockchain ecosystem. This charm can be deployed as a validator, collator, bootnode, or RPC on any Polkadot derived blockchain, also known as parachains. The deployment config differs depending on the chain that is being deployed.
 
-The charm starts the Polkadot client as a service, which takes its arguments from `/etc/default/polkadot` which in turn are set by the Juju config *service-args*. The Polkadot client itself is downloaded and installed from the config *binary-url*. Blockchain data is stored in the default client path unless the Juju config `data-dir` is set at deployment time.
+The charm starts the Polkadot client as a service, which takes its arguments from `/etc/default/<juju-app-name>` which in turn are set by the Juju config *service-args*. The Polkadot client itself is downloaded and installed from the config *binary-url*. Blockchain data is stored in the default client path unless the Juju config `data-dir` is set at deployment time.
 
 ## Building
 
@@ -52,6 +52,9 @@ However, there are some configs which are required by the charm to correctly ins
     - Note: from Polkadot release 1.1.0, the binary is split into three separate parts which means three separate URL:s will need to be set to the `binary-url` config, in a space separated list.
 - `service-args="... ..."` with the tags `--chain=...` and `--rpc-port=...` set
 - Optional: `data-dir=/mnt/blockchaindata0/polkadot` to override the Polkadot `--base-path` for either binary or snap workloads. This must be set at deployment time.
+- Optional: set `--prometheus-port=...` in `service-args` when multiple nodes run on the same machine. If omitted, the charm advertises the default Polkadot metrics port `9615`.
+
+When deploying multiple applications to the same machine, use a distinct Juju application name for each deployment, for example `juju deploy polkadot foo-bar`. Binary deployments use that application name for the Unix user, home directory, systemd service, and `/etc/default` file. Snap deployments use snap parallel instances; the snap instance key is the first 10 characters of the SHA1 hash of the Juju application name.
 
 With those configs included, a standard deployment of the Polkadot node could look like:
 

--- a/actions.yaml
+++ b/actions.yaml
@@ -47,7 +47,7 @@ insert-key:
   required: [ mnemonic, address ]
 set-node-key:
   description: |
-    Sets a new private key in '/home/polkadot/node-key' and restarts the node service.
+    Sets a new private key in the node key file for this Juju application and restarts the node service.
     A node key can be generated with the external tool subkey (not provided by the charm) E.g. `subkey generate-node-key --file node-key`.
     The content of node-key is the private key and what should be used for the 'key' parameter.
   params:

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,7 @@ options:
     description: |
       Extra arguments that the service should run with.
       '--chain=... --rpc-port=...' are required to set for the charm to run.
+      Set '--prometheus-port=...' when multiple nodes run on the same machine.
   data-dir:
     type: string
     default: ""
@@ -65,7 +66,7 @@ options:
     description: |
       URL where one or more wasm runtime files can be found.
       The file can either be a .wasm file or a tar.gz archive containing one or more wasm runtime files.
-      If set, the downloaded files(s) will be in /home/polkadot/wasm and the service argument `--wasm-runtime-overrides=/home/polkadot/wasm` will be used.
+      If set, the downloaded file(s) will be in /home/<juju-app-name>/wasm for binary workloads and the service argument `--wasm-runtime-overrides=/home/<juju-app-name>/wasm` will be used.
   mnemonic-secret-id:
     type: secret
     description: |

--- a/lib/charms/dwellir_observability/v0/machine_observability.py
+++ b/lib/charms/dwellir_observability/v0/machine_observability.py
@@ -110,6 +110,7 @@ def build_machine_observability_payload(
     service_name: str,
     charm_name: str,
     source_topology: SourceTopology | None = None,
+    metrics_port: str = "9615",
 ) -> MachineObservabilityPayload:
     """Build a typed source-only observability payload for publication."""
 
@@ -125,7 +126,7 @@ def build_machine_observability_payload(
         journal_match_expressions=[],
         metrics_endpoints=[
             MetricsEndpoint(
-                targets=["localhost:9615"],
+                targets=[f"localhost:{metrics_port}"],
                 path="/metrics",
                 scheme="http",
             )

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,7 +5,7 @@ display-name: Polkadot node
 summary: |
   Polkadot is a web3 blockchain ecosystem.
 description: |
-    The charm starts the Polkadot client as a service, taking startup arguments from /etc/default/polkadot and is set by the juju config *service-args*. The Polkadot client itself is downloaded and installed from the charm config *binary-url*. See: https://github.com/paritytech/polkadot/ for available releases.
+    The charm starts the Polkadot client as a service, taking startup arguments from /etc/default/<juju-app-name> and is set by the juju config *service-args*. The Polkadot client itself is downloaded and installed from the charm config *binary-url*. See: https://github.com/paritytech/polkadot/ for available releases.
 
     The charm is capable of running all polkadot parachains by setting the service-args.
     

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,6 +21,7 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from urllib3.exceptions import MaxRetryError, NewConnectionError
 
 from core import constants as c
+from core import runtime as r
 from core import runtime_identity
 from core.managers import PolkadotSnapManager, WorkloadFactory, WorkloadType
 from core.service_args import ServiceArgs
@@ -691,7 +692,7 @@ class PolkadotCharm(ops.CharmBase):
             app_name = getattr(getattr(self, "app", None), "name", c.DEFAULT_APP_NAME)
             service_name = runtime_identity.snap_config_for_app(app_name)[snap_name]["systemd_service"]
         else:
-            app_name = getattr(getattr(self, "app", None), "name", c.USER)
+            app_name = getattr(getattr(self, "app", None), "name", r.user)
             service_name = f"{app_name}.service"
         try:
             metrics_port = ServiceArgs(self.config, []).prometheus_port

--- a/src/charm.py
+++ b/src/charm.py
@@ -45,7 +45,7 @@ class PolkadotCharm(ops.CharmBase):
         super().__init__(*args)
         runtime_identity.configure_runtime_identity(self.app.name)
         try:
-            metrics_port = ServiceArgs(self.config, []).prometheus_port
+            metrics_port = ServiceArgs(self.config, {}).prometheus_port
         except ValueError:
             metrics_port = c.DEFAULT_PROMETHEUS_PORT
         self.prometheus_polkadot_provider = PrometheusProvider(self, "polkadot-prometheus", metrics_port, "/metrics")
@@ -695,7 +695,7 @@ class PolkadotCharm(ops.CharmBase):
             app_name = getattr(getattr(self, "app", None), "name", r.user)
             service_name = f"{app_name}.service"
         try:
-            metrics_port = ServiceArgs(self.config, []).prometheus_port
+            metrics_port = ServiceArgs(self.config, {}).prometheus_port
         except ValueError:
             metrics_port = c.DEFAULT_PROMETHEUS_PORT
         return build_machine_observability_payload(

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,6 +20,8 @@ from charms.grafana_agent.v0.cos_agent import COSAgentProvider
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from urllib3.exceptions import MaxRetryError, NewConnectionError
 
+from core import constants as c
+from core import runtime_identity
 from core.managers import PolkadotSnapManager, WorkloadFactory, WorkloadType
 from core.service_args import ServiceArgs
 from core.utils import general_util, user_group_util
@@ -40,7 +42,12 @@ class PolkadotCharm(ops.CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.prometheus_polkadot_provider = PrometheusProvider(self, "polkadot-prometheus", 9615, "/metrics")
+        runtime_identity.configure_runtime_identity(self.app.name)
+        try:
+            metrics_port = ServiceArgs(self.config, []).prometheus_port
+        except ValueError:
+            metrics_port = c.DEFAULT_PROMETHEUS_PORT
+        self.prometheus_polkadot_provider = PrometheusProvider(self, "polkadot-prometheus", metrics_port, "/metrics")
         self.rpc_url_provider = RpcUrlProvider(self, "rpc-url")
         self.rpc_url_requirer = RpcUrlRequirer(self, "relay-rpc-url")
         self.machine_observability_provider = MachineObservabilityProvider(
@@ -52,7 +59,7 @@ class PolkadotCharm(ops.CharmBase):
         self.cos_agent_provider = COSAgentProvider(
             self,
             relation_name="grafana-agent",
-            metrics_endpoints=[{"port": 9615, "path": "/metrics"}],
+            metrics_endpoints=[{"port": int(metrics_port), "path": "/metrics"}],
             refresh_events=[self.on.update_status, self.on.upgrade_charm],
             metrics_rules_dir="./src/alert_rules/prometheus",
             logs_rules_dir="./src/alert_rules/loki",
@@ -269,6 +276,7 @@ class PolkadotCharm(ops.CharmBase):
             self.unit.status = ops.MaintenanceStatus("Updating service args")
             self._workload.set_service_args(service_args_obj.service_args_string)
             self._stored.service_args = self.config.get("service-args")
+            self._refresh_advertised_ports(service_args_obj.prometheus_port)
 
         if self._stored.chain_spec_url != self.config.get("chain-spec-url"):
             try:
@@ -357,6 +365,13 @@ class PolkadotCharm(ops.CharmBase):
 
         self._publish_machine_observability()
         self.update_status_simple()
+
+    def _refresh_advertised_ports(self, metrics_port: str) -> None:
+        """Refresh relation data that depends on service-args ports."""
+        self.prometheus_polkadot_provider.set_port(metrics_port)
+        self.cos_agent_provider._metrics_endpoints = [{"port": int(metrics_port), "path": "/metrics"}]
+        self.cos_agent_provider._on_refresh(None)
+        self._publish_machine_observability()
 
     def _on_update_status(self, event: ops.UpdateStatusEvent) -> None:
         self._publish_machine_observability()
@@ -673,13 +688,20 @@ class PolkadotCharm(ops.CharmBase):
 
         snap_name = self.config.get("snap-name") or self._stored.snap_name
         if snap_name:
-            service_name = f"snap.{snap_name}.{snap_name}.service"
+            app_name = getattr(getattr(self, "app", None), "name", c.DEFAULT_APP_NAME)
+            service_name = runtime_identity.snap_config_for_app(app_name)[snap_name]["systemd_service"]
         else:
-            service_name = "polkadot.service"
+            app_name = getattr(getattr(self, "app", None), "name", c.USER)
+            service_name = f"{app_name}.service"
+        try:
+            metrics_port = ServiceArgs(self.config, []).prometheus_port
+        except ValueError:
+            metrics_port = c.DEFAULT_PROMETHEUS_PORT
         return build_machine_observability_payload(
             service_name=service_name,
             charm_name=self.meta.name,
             source_topology=self._source_topology(),
+            metrics_port=metrics_port,
         )
 
     def _source_topology(self) -> SourceTopology:

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+DEFAULT_APP_NAME = "polkadot"
+DEFAULT_PROMETHEUS_PORT = "9615"
 USER = "polkadot"
 SERVICE_NAME = USER
 HOME_DIR = Path("/home/polkadot")
@@ -16,10 +18,25 @@ DB_RELAY_DIR = Path(BASE_PATH, "polkadot")
 WASM_DIR = Path(HOME_DIR, "wasm")
 
 SNAP_USER = "root"
-SNAP_CONFIG = {
+SNAP_INSTANCE_KEY = ""
+DEFAULT_SNAP_CONFIG = {
     "polkadot": {
         "snap_name": "polkadot",
         "service_name": "polkadot",
+        "cli_app": "polkadot-cli",
+        "binary_name": "polkadot",
+    },
+    "polkadot-parachain": {
+        "snap_name": "polkadot-parachain",
+        "service_name": "polkadot-parachain",
+        "cli_app": "cli",
+        "binary_name": "polkadot-parachain",
+    },
+}
+SNAP_CONFIG = {
+    "polkadot": {
+        **DEFAULT_SNAP_CONFIG["polkadot"],
+        "base_snap_name": "polkadot",
         "cli_command": "polkadot.polkadot-cli",
         "base_path": Path("/var/snap/polkadot/common/polkadot_base"),
         "snap_binary_path": Path("/snap/polkadot/current/bin/polkadot"),
@@ -28,10 +45,11 @@ SNAP_CONFIG = {
         "relay_db_dir": Path("/var/snap/polkadot/common/polkadot_base/polkadot"),
         "wasm_dir": Path("/var/snap/polkadot/common/polkadot_base/wasm"),
         "node_key_file": Path("/var/snap/polkadot/common/node-key"),
+        "systemd_service": "snap.polkadot.polkadot.service",
     },
     "polkadot-parachain": {
-        "snap_name": "polkadot-parachain",
-        "service_name": "polkadot-parachain",
+        **DEFAULT_SNAP_CONFIG["polkadot-parachain"],
+        "base_snap_name": "polkadot-parachain",
         "cli_command": "polkadot-parachain.cli",
         "base_path": Path("/var/snap/polkadot-parachain/common/polkadot_base"),
         "snap_binary_path": Path("/snap/polkadot-parachain/current/bin/polkadot-parachain"),
@@ -40,9 +58,11 @@ SNAP_CONFIG = {
         "relay_db_dir": Path("/var/snap/polkadot-parachain/common/polkadot_base/polkadot"),
         "wasm_dir": Path("/var/snap/polkadot-parachain/common/polkadot_base/wasm"),
         "node_key_file": Path("/var/snap/polkadot-parachain/common/node-key"),
+        "systemd_service": "snap.polkadot-parachain.polkadot-parachain.service",
     },
 }
 
+DOCKER_CONTAINER_NAME = "polkadot-install-tmp"
 DOCKER_DEAMON_CONFIG_PATH = Path("/etc/docker/daemon.json")
 DOCKER_DEAMON_JSON_CONFIG = """{
   "storage-driver": "fuse-overlayfs"

--- a/src/core/constants.py
+++ b/src/core/constants.py
@@ -4,21 +4,7 @@ from pathlib import Path
 
 DEFAULT_APP_NAME = "polkadot"
 DEFAULT_PROMETHEUS_PORT = "9615"
-USER = "polkadot"
-SERVICE_NAME = USER
-HOME_DIR = Path("/home/polkadot")
-BASE_PATH = Path(HOME_DIR, ".local/share/polkadot")
-BINARY_FILE = Path(HOME_DIR, "polkadot")
-EXECUTE_WORKER_BINARY_FILE = {"default": Path(HOME_DIR, "polkadot-execute-worker"), "enjin": Path(HOME_DIR, "enjin-execute-worker"), "canary": Path(HOME_DIR, "enjin-execute-worker")}
-PREPARE_WORKER_BINARY_FILE = {"default": Path(HOME_DIR, "polkadot-prepare-worker"), "enjin": Path(HOME_DIR, "enjin-prepare-worker"), "canary": Path(HOME_DIR, "enjin-prepare-worker")}
-CHAIN_SPEC_DIR = Path(HOME_DIR, "spec")
-NODE_KEY_FILE = Path(HOME_DIR, "node-key")
-DB_CHAIN_DIR = Path(BASE_PATH, "chains")
-DB_RELAY_DIR = Path(BASE_PATH, "polkadot")
-WASM_DIR = Path(HOME_DIR, "wasm")
-
 SNAP_USER = "root"
-SNAP_INSTANCE_KEY = ""
 DEFAULT_SNAP_CONFIG = {
     "polkadot": {
         "snap_name": "polkadot",
@@ -33,36 +19,7 @@ DEFAULT_SNAP_CONFIG = {
         "binary_name": "polkadot-parachain",
     },
 }
-SNAP_CONFIG = {
-    "polkadot": {
-        **DEFAULT_SNAP_CONFIG["polkadot"],
-        "base_snap_name": "polkadot",
-        "cli_command": "polkadot.polkadot-cli",
-        "base_path": Path("/var/snap/polkadot/common/polkadot_base"),
-        "snap_binary_path": Path("/snap/polkadot/current/bin/polkadot"),
-        "chain_spec_dir": Path("/var/snap/polkadot/common/spec"),
-        "chain_db_dir": Path("/var/snap/polkadot/common/polkadot_base/chains"),
-        "relay_db_dir": Path("/var/snap/polkadot/common/polkadot_base/polkadot"),
-        "wasm_dir": Path("/var/snap/polkadot/common/polkadot_base/wasm"),
-        "node_key_file": Path("/var/snap/polkadot/common/node-key"),
-        "systemd_service": "snap.polkadot.polkadot.service",
-    },
-    "polkadot-parachain": {
-        **DEFAULT_SNAP_CONFIG["polkadot-parachain"],
-        "base_snap_name": "polkadot-parachain",
-        "cli_command": "polkadot-parachain.cli",
-        "base_path": Path("/var/snap/polkadot-parachain/common/polkadot_base"),
-        "snap_binary_path": Path("/snap/polkadot-parachain/current/bin/polkadot-parachain"),
-        "chain_spec_dir": Path("/var/snap/polkadot-parachain/common/spec"),
-        "chain_db_dir": Path("/var/snap/polkadot-parachain/common/polkadot_base/chains"),
-        "relay_db_dir": Path("/var/snap/polkadot-parachain/common/polkadot_base/polkadot"),
-        "wasm_dir": Path("/var/snap/polkadot-parachain/common/polkadot_base/wasm"),
-        "node_key_file": Path("/var/snap/polkadot-parachain/common/node-key"),
-        "systemd_service": "snap.polkadot-parachain.polkadot-parachain.service",
-    },
-}
 
-DOCKER_CONTAINER_NAME = "polkadot-install-tmp"
 DOCKER_DEAMON_CONFIG_PATH = Path("/etc/docker/daemon.json")
 DOCKER_DEAMON_JSON_CONFIG = """{
   "storage-driver": "fuse-overlayfs"

--- a/src/core/managers/polkadot_binary.py
+++ b/src/core/managers/polkadot_binary.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from core import constants as c
+from core import runtime as r
 from core.utils import binary_util, download_util, general_util
 
 from .workload import WorkloadManager, WorkloadType
@@ -16,7 +16,7 @@ class PolkadotBinaryManager(WorkloadManager):
         self._binary_sha256_url = kwargs.get("binary_sha256_url")
         self._docker_tag = kwargs.get("docker_tag")
         self._data_dir = Path(kwargs.get("data_dir")) if kwargs.get("data_dir") else None
-        self._base_path = self._data_dir or c.BASE_PATH
+        self._base_path = self._data_dir or r.base_path
         self._chain_db_dir = Path(self._base_path, "chains")
         self._relay_db_dir = Path(self._base_path, "polkadot")
         self._service_template_path = Path(kwargs.get("charm_base_dir"), "templates/etc/systemd/system/polkadot.service")
@@ -24,7 +24,7 @@ class PolkadotBinaryManager(WorkloadManager):
     def install(self):
         if not self._binary_url and not self._docker_tag:
             raise ValueError("Either 'binary_url' or 'docker_tag' must be provided for binary installation.")
-        if self._data_dir and not general_util.setup_data_dir(self._base_path, c.USER):
+        if self._data_dir and not general_util.setup_data_dir(self._base_path, r.user):
             raise ValueError(f"Failed to set up data-dir {self._base_path}")
         if self._binary_url:
             binary_util.install_binary(self._chain_name, self._binary_url, self._binary_sha256_url)
@@ -73,7 +73,7 @@ class PolkadotBinaryManager(WorkloadManager):
         binary_util.generate_node_key()
 
     def download_wasm_runtime(self, url: str) -> None:
-        download_util.download_wasm_runtime(url, c.WASM_DIR, c.USER)
+        download_util.download_wasm_runtime(url, r.wasm_dir, r.user)
 
     def get_binary_version(self) -> str:
         return binary_util.get_binary_version()
@@ -88,7 +88,7 @@ class PolkadotBinaryManager(WorkloadManager):
         return binary_util.get_service_args()
 
     def get_wasm_info(self):
-        return general_util.get_wasm_info(c.WASM_DIR)
+        return general_util.get_wasm_info(r.wasm_dir)
 
     def set_service_args(self, service_args: str) -> None:
         return binary_util.update_service_args(service_args)
@@ -103,7 +103,7 @@ class PolkadotBinaryManager(WorkloadManager):
         return binary_util.get_binary_last_changed()
 
     def get_proc_cmdline(self) -> str:
-        return general_util.get_process_cmdline(c.USER)
+        return general_util.get_process_cmdline(r.user)
 
     def is_relay_chain_node(self) -> bool:
         return binary_util.is_relay_chain_node(self._chain_db_dir, self._relay_db_dir)
@@ -112,7 +112,7 @@ class PolkadotBinaryManager(WorkloadManager):
         return binary_util.is_parachain_node(self._chain_db_dir, self._relay_db_dir)
 
     def write_node_key_file(self, key) -> None:
-        general_util.write_node_key_file(c.NODE_KEY_FILE, key, c.USER)
+        general_util.write_node_key_file(r.node_key_file, key, r.user)
 
     def get_relay_for_parachain(self):
         return binary_util.get_relay_for_parachain(self._chain_db_dir, self._relay_db_dir)

--- a/src/core/managers/polkadot_snap.py
+++ b/src/core/managers/polkadot_snap.py
@@ -74,11 +74,35 @@ class PolkadotSnapManager(WorkloadManager):
         self._relay_db_dir = Path(self._base_path, "polkadot")
 
         try:
+            if c.SNAP_INSTANCE_KEY:
+                self._enable_parallel_instances()
             cache = snap.SnapCache()
-            self._polkadot_snap = cache[self._snap_config.get("snap_name")]
+            self._polkadot_snap = self._load_snap(cache)
         except Exception as e:
             logger.error(f"Failed to initialize snap cache: {e}")
             raise PolkadotError(f"Failed to initialize: {e}")
+
+    def _load_snap(self, cache: snap.SnapCache) -> snap.Snap:
+        instance_snap_name = self._snap_config.get("snap_name")
+        try:
+            return cache[instance_snap_name]
+        except snap.SnapNotFoundError:
+            if not c.SNAP_INSTANCE_KEY:
+                raise
+            base_snap = cache[self._snap_config.get("base_snap_name")]
+            return snap.Snap(
+                name=instance_snap_name,
+                state=snap.SnapState.Available,
+                channel=base_snap.channel,
+                revision=base_snap.revision,
+                confinement=base_snap.confinement,
+            )
+
+    def _enable_parallel_instances(self) -> None:
+        sp.run(
+            ["snap", "set", "system", "experimental.parallel-instances=true"],
+            check=True,
+        )
 
     def install(self):
         if self._polkadot_snap.present:
@@ -114,9 +138,18 @@ class PolkadotSnapManager(WorkloadManager):
             logger.info(f"{self._snap_config.get('snap_name')} installed successfully")
 
             logger.info(f"Setting connection plugs for {self._snap_config.get('snap_name')}")
-            self._polkadot_snap.connect(plug="hardware-observe", service="polkadot")
-            self._polkadot_snap.connect(plug="system-observe", service="polkadot")
-            self._polkadot_snap.connect(plug="removable-media", service="polkadot")
+            self._polkadot_snap.connect(
+                plug="hardware-observe",
+                service=self._snap_config.get("snap_name"),
+            )
+            self._polkadot_snap.connect(
+                plug="system-observe",
+                service=self._snap_config.get("snap_name"),
+            )
+            self._polkadot_snap.connect(
+                plug="removable-media",
+                service=self._snap_config.get("snap_name"),
+            )
             logger.info(f"Connection plugs set successfully for {self._snap_config.get('snap_name')}")
 
         except Exception as e:

--- a/src/core/managers/polkadot_snap.py
+++ b/src/core/managers/polkadot_snap.py
@@ -18,6 +18,7 @@ from typing import Optional
 from charms.operator_libs_linux.v2 import snap
 
 from core import constants as c
+from core import runtime as r
 from core.exceptions import InstallError, PolkadotError, ServiceError
 from core.managers import WorkloadManager, WorkloadType
 from core.utils import download_util, general_util
@@ -58,23 +59,23 @@ class PolkadotSnapManager(WorkloadManager):
     def configure(self, **kwargs):
         self._snap_name = kwargs.get("snap_name")
         if not self._snap_name:
-            raise ValueError(f"No snap-name provided. Please specify one of {list(c.SNAP_CONFIG.keys())}.")
-        if self._snap_name not in c.SNAP_CONFIG:
-            raise ValueError(f"Invalid snap-name provided: {self._snap_name}. Must be one of {list(c.SNAP_CONFIG.keys())}.")
+            raise ValueError(f"No snap-name provided. Please specify one of {list(r.snap_config.keys())}.")
+        if self._snap_name not in r.snap_config:
+            raise ValueError(f"Invalid snap-name provided: {self._snap_name}. Must be one of {list(r.snap_config.keys())}.")
 
         self._channel = kwargs.get("channel") if kwargs.get("channel") else None
         self._revision = kwargs.get("revision") if kwargs.get("revision") else None
         self._hold = kwargs.get("hold") if kwargs.get("hold") else None
         self._endure = kwargs.get("endure") if kwargs.get("endure") else None
         self._type = kwargs.get("chain-type")
-        self._snap_config = c.SNAP_CONFIG[self._snap_name]
+        self._snap_config = r.snap_config[self._snap_name]
         self._data_dir = Path(kwargs.get("data_dir")) if kwargs.get("data_dir") else None
         self._base_path = self._data_dir or self._snap_config.get("base_path")
         self._chain_db_dir = Path(self._base_path, "chains")
         self._relay_db_dir = Path(self._base_path, "polkadot")
 
         try:
-            if c.SNAP_INSTANCE_KEY:
+            if r.snap_instance_key:
                 self._enable_parallel_instances()
             cache = snap.SnapCache()
             self._polkadot_snap = self._load_snap(cache)
@@ -87,7 +88,7 @@ class PolkadotSnapManager(WorkloadManager):
         try:
             return cache[instance_snap_name]
         except snap.SnapNotFoundError:
-            if not c.SNAP_INSTANCE_KEY:
+            if not r.snap_instance_key:
                 raise
             base_snap = cache[self._snap_config.get("base_snap_name")]
             return snap.Snap(

--- a/src/core/runtime.py
+++ b/src/core/runtime.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+
+from core import constants as c
+
+app_name = c.DEFAULT_APP_NAME
+user = c.DEFAULT_APP_NAME
+service_name = user
+home_dir = Path("/home/polkadot")
+base_path = Path(home_dir, ".local/share/polkadot")
+binary_file = Path(home_dir, "polkadot")
+execute_worker_binary_file = {"default": Path(home_dir, "polkadot-execute-worker"), "enjin": Path(home_dir, "enjin-execute-worker"), "canary": Path(home_dir, "enjin-execute-worker")}
+prepare_worker_binary_file = {"default": Path(home_dir, "polkadot-prepare-worker"), "enjin": Path(home_dir, "enjin-prepare-worker"), "canary": Path(home_dir, "enjin-prepare-worker")}
+chain_spec_dir = Path(home_dir, "spec")
+node_key_file = Path(home_dir, "node-key")
+db_chain_dir = Path(base_path, "chains")
+db_relay_dir = Path(base_path, "polkadot")
+wasm_dir = Path(home_dir, "wasm")
+
+snap_instance_key = ""
+
+
+def build_snap_config(instance_key: str) -> dict:
+    snap_config = {}
+    for config_name, base_config in c.DEFAULT_SNAP_CONFIG.items():
+        base_snap_name = base_config["snap_name"]
+        snap_name = base_snap_name if not instance_key else f"{base_snap_name}_{instance_key}"
+        base_path = Path("/var/snap", snap_name, "common/polkadot_base")
+        snap_config[config_name] = {
+            **base_config,
+            "snap_name": snap_name,
+            "base_snap_name": base_snap_name,
+            "cli_command": f"{snap_name}.{base_config['cli_app']}",
+            "base_path": base_path,
+            "snap_binary_path": Path(
+                "/snap",
+                snap_name,
+                "current/bin",
+                base_config["binary_name"],
+            ),
+            "chain_spec_dir": Path("/var/snap", snap_name, "common/spec"),
+            "chain_db_dir": Path(base_path, "chains"),
+            "relay_db_dir": Path(base_path, "polkadot"),
+            "wasm_dir": Path(base_path, "wasm"),
+            "node_key_file": Path("/var/snap", snap_name, "common/node-key"),
+            "systemd_service": f"snap.{snap_name}.{base_config['service_name']}.service",
+        }
+    return snap_config
+
+
+snap_config = build_snap_config(snap_instance_key)
+
+docker_container_name = "polkadot-install-tmp"

--- a/src/core/runtime_identity.py
+++ b/src/core/runtime_identity.py
@@ -4,6 +4,7 @@ import hashlib
 from pathlib import Path
 
 from core import constants as c
+from core import runtime as r
 
 
 def snap_instance_key(app_name: str) -> str:
@@ -13,59 +14,26 @@ def snap_instance_key(app_name: str) -> str:
     return hashlib.sha1(app_name.encode("utf-8")).hexdigest()[:10]
 
 
-def _snap_instance_name(base_snap_name: str, instance_key: str) -> str:
-    if not instance_key:
-        return base_snap_name
-    return f"{base_snap_name}_{instance_key}"
-
-
-def _build_snap_config(instance_key: str) -> dict:
-    snap_config = {}
-    for config_name, base_config in c.DEFAULT_SNAP_CONFIG.items():
-        base_snap_name = base_config["snap_name"]
-        snap_name = _snap_instance_name(base_snap_name, instance_key)
-        base_path = Path("/var/snap", snap_name, "common/polkadot_base")
-        snap_config[config_name] = {
-            **base_config,
-            "snap_name": snap_name,
-            "base_snap_name": base_snap_name,
-            "cli_command": f"{snap_name}.{base_config['cli_app']}",
-            "base_path": base_path,
-            "snap_binary_path": Path(
-                "/snap",
-                snap_name,
-                "current/bin",
-                base_config["binary_name"],
-            ),
-            "chain_spec_dir": Path("/var/snap", snap_name, "common/spec"),
-            "chain_db_dir": Path(base_path, "chains"),
-            "relay_db_dir": Path(base_path, "polkadot"),
-            "wasm_dir": Path(base_path, "wasm"),
-            "node_key_file": Path("/var/snap", snap_name, "common/node-key"),
-            "systemd_service": f"snap.{snap_name}.{base_config['service_name']}.service",
-        }
-    return snap_config
-
-
 def snap_config_for_app(app_name: str) -> dict:
     """Return snap configuration for an application name without mutating globals."""
-    return _build_snap_config(snap_instance_key(app_name))
+    return r.build_snap_config(snap_instance_key(app_name))
 
 
 def configure_runtime_identity(app_name: str) -> None:
     """Configure host-level resource names from the Juju application name."""
-    c.USER = app_name
-    c.SERVICE_NAME = c.USER
-    c.HOME_DIR = Path("/home", c.USER)
-    c.BASE_PATH = Path(c.HOME_DIR, ".local/share/polkadot")
-    c.BINARY_FILE = Path(c.HOME_DIR, "polkadot")
-    c.EXECUTE_WORKER_BINARY_FILE = {"default": Path(c.HOME_DIR, "polkadot-execute-worker"), "enjin": Path(c.HOME_DIR, "enjin-execute-worker"), "canary": Path(c.HOME_DIR, "enjin-execute-worker")}
-    c.PREPARE_WORKER_BINARY_FILE = {"default": Path(c.HOME_DIR, "polkadot-prepare-worker"), "enjin": Path(c.HOME_DIR, "enjin-prepare-worker"), "canary": Path(c.HOME_DIR, "enjin-prepare-worker")}
-    c.CHAIN_SPEC_DIR = Path(c.HOME_DIR, "spec")
-    c.NODE_KEY_FILE = Path(c.HOME_DIR, "node-key")
-    c.DB_CHAIN_DIR = Path(c.BASE_PATH, "chains")
-    c.DB_RELAY_DIR = Path(c.BASE_PATH, "polkadot")
-    c.WASM_DIR = Path(c.HOME_DIR, "wasm")
-    c.SNAP_INSTANCE_KEY = snap_instance_key(app_name)
-    c.SNAP_CONFIG = _build_snap_config(c.SNAP_INSTANCE_KEY)
-    c.DOCKER_CONTAINER_NAME = f"{c.USER}-install-tmp"
+    r.app_name = app_name
+    r.user = app_name
+    r.service_name = r.user
+    r.home_dir = Path("/home", r.user)
+    r.base_path = Path(r.home_dir, ".local/share/polkadot")
+    r.binary_file = Path(r.home_dir, "polkadot")
+    r.execute_worker_binary_file = {"default": Path(r.home_dir, "polkadot-execute-worker"), "enjin": Path(r.home_dir, "enjin-execute-worker"), "canary": Path(r.home_dir, "enjin-execute-worker")}
+    r.prepare_worker_binary_file = {"default": Path(r.home_dir, "polkadot-prepare-worker"), "enjin": Path(r.home_dir, "enjin-prepare-worker"), "canary": Path(r.home_dir, "enjin-prepare-worker")}
+    r.chain_spec_dir = Path(r.home_dir, "spec")
+    r.node_key_file = Path(r.home_dir, "node-key")
+    r.db_chain_dir = Path(r.base_path, "chains")
+    r.db_relay_dir = Path(r.base_path, "polkadot")
+    r.wasm_dir = Path(r.home_dir, "wasm")
+    r.snap_instance_key = snap_instance_key(app_name)
+    r.snap_config = r.build_snap_config(r.snap_instance_key)
+    r.docker_container_name = f"{r.user}-install-tmp"

--- a/src/core/runtime_identity.py
+++ b/src/core/runtime_identity.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+import hashlib
+from pathlib import Path
+
+from core import constants as c
+
+
+def snap_instance_key(app_name: str) -> str:
+    """Return the snap parallel-instance key for an application name."""
+    if app_name == c.DEFAULT_APP_NAME:
+        return ""
+    return hashlib.sha1(app_name.encode("utf-8")).hexdigest()[:10]
+
+
+def _snap_instance_name(base_snap_name: str, instance_key: str) -> str:
+    if not instance_key:
+        return base_snap_name
+    return f"{base_snap_name}_{instance_key}"
+
+
+def _build_snap_config(instance_key: str) -> dict:
+    snap_config = {}
+    for config_name, base_config in c.DEFAULT_SNAP_CONFIG.items():
+        base_snap_name = base_config["snap_name"]
+        snap_name = _snap_instance_name(base_snap_name, instance_key)
+        base_path = Path("/var/snap", snap_name, "common/polkadot_base")
+        snap_config[config_name] = {
+            **base_config,
+            "snap_name": snap_name,
+            "base_snap_name": base_snap_name,
+            "cli_command": f"{snap_name}.{base_config['cli_app']}",
+            "base_path": base_path,
+            "snap_binary_path": Path(
+                "/snap",
+                snap_name,
+                "current/bin",
+                base_config["binary_name"],
+            ),
+            "chain_spec_dir": Path("/var/snap", snap_name, "common/spec"),
+            "chain_db_dir": Path(base_path, "chains"),
+            "relay_db_dir": Path(base_path, "polkadot"),
+            "wasm_dir": Path(base_path, "wasm"),
+            "node_key_file": Path("/var/snap", snap_name, "common/node-key"),
+            "systemd_service": f"snap.{snap_name}.{base_config['service_name']}.service",
+        }
+    return snap_config
+
+
+def snap_config_for_app(app_name: str) -> dict:
+    """Return snap configuration for an application name without mutating globals."""
+    return _build_snap_config(snap_instance_key(app_name))
+
+
+def configure_runtime_identity(app_name: str) -> None:
+    """Configure host-level resource names from the Juju application name."""
+    c.USER = app_name
+    c.SERVICE_NAME = c.USER
+    c.HOME_DIR = Path("/home", c.USER)
+    c.BASE_PATH = Path(c.HOME_DIR, ".local/share/polkadot")
+    c.BINARY_FILE = Path(c.HOME_DIR, "polkadot")
+    c.EXECUTE_WORKER_BINARY_FILE = {"default": Path(c.HOME_DIR, "polkadot-execute-worker"), "enjin": Path(c.HOME_DIR, "enjin-execute-worker"), "canary": Path(c.HOME_DIR, "enjin-execute-worker")}
+    c.PREPARE_WORKER_BINARY_FILE = {"default": Path(c.HOME_DIR, "polkadot-prepare-worker"), "enjin": Path(c.HOME_DIR, "enjin-prepare-worker"), "canary": Path(c.HOME_DIR, "enjin-prepare-worker")}
+    c.CHAIN_SPEC_DIR = Path(c.HOME_DIR, "spec")
+    c.NODE_KEY_FILE = Path(c.HOME_DIR, "node-key")
+    c.DB_CHAIN_DIR = Path(c.BASE_PATH, "chains")
+    c.DB_RELAY_DIR = Path(c.BASE_PATH, "polkadot")
+    c.WASM_DIR = Path(c.HOME_DIR, "wasm")
+    c.SNAP_INSTANCE_KEY = snap_instance_key(app_name)
+    c.SNAP_CONFIG = _build_snap_config(c.SNAP_INSTANCE_KEY)
+    c.DOCKER_CONTAINER_NAME = f"{c.USER}-install-tmp"

--- a/src/core/service_args.py
+++ b/src/core/service_args.py
@@ -73,6 +73,15 @@ class ServiceArgs:
         """Check if the node is running as a binary or snap."""
         return self._is_binary
 
+    @property
+    def prometheus_port(self) -> str:
+        """Get the Prometheus port used by the node."""
+        try:
+            i = self.service_args_list.index("--prometheus-port")
+            return self.service_args_list[i + 1]
+        except ValueError:
+            return c.DEFAULT_PROMETHEUS_PORT
+
     def __check_service_args(self, service_args: str | list):
         msg = ""
         # Check for service arguments that must be set.
@@ -82,8 +91,6 @@ class ServiceArgs:
             msg += "'--rpc-port' must be set in 'service-args'.\n"
 
         # Check for service arguments that must NOT be set.
-        if "--prometheus-port" in service_args:
-            msg += "'--prometheus-port' may not be set! Charm assumes default port 9615.\n"
         if "--node-key-file" in service_args:
             msg += f"'--node-key-file' may not be set! Path is hardcoded to {c.NODE_KEY_FILE}\n"
         if "--base-path" in service_args:

--- a/src/core/service_args.py
+++ b/src/core/service_args.py
@@ -5,6 +5,7 @@ import re
 from ops.model import ConfigData
 
 import core.constants as c
+from core import runtime as r
 from core.utils.download_util import download_chain_spec
 
 
@@ -23,7 +24,7 @@ class ServiceArgs:
 
         if not self._is_binary and not config.get("snap-name"):
             raise ValueError("Either 'docker-tag', 'binary-url' or 'snap-name' must be set.")
-        self._snap_config = c.SNAP_CONFIG.get(config.get("snap-name")) if config.get("snap-name") else None
+        self._snap_config = r.snap_config.get(config.get("snap-name")) if config.get("snap-name") else None
 
         self.service_args_list = self.__service_args_to_list(service_args)
         self.__check_service_args(self.service_args_list)
@@ -92,7 +93,7 @@ class ServiceArgs:
 
         # Check for service arguments that must NOT be set.
         if "--node-key-file" in service_args:
-            msg += f"'--node-key-file' may not be set! Path is hardcoded to {c.NODE_KEY_FILE}\n"
+            msg += f"'--node-key-file' may not be set! Path is hardcoded to {r.node_key_file}\n"
         if "--base-path" in service_args:
             msg += "'--base-path' may not be set! Charm handles this automatically.\n"
 
@@ -133,7 +134,7 @@ class ServiceArgs:
         self.service_args_list_customized = self.service_args_list_customized + args
 
     def __customize_service_args(self):  # noqa: C901
-        self.__add_firstchain_args(["--node-key-file", c.NODE_KEY_FILE if self._is_binary else self._snap_config.get("node_key_file")])
+        self.__add_firstchain_args(["--node-key-file", r.node_key_file if self._is_binary else self._snap_config.get("node_key_file")])
         if self._relay_rpc_urls:
             self.__add_firstchain_args(["--relay-chain-rpc-urls", *self._relay_rpc_urls])
 
@@ -146,8 +147,8 @@ class ServiceArgs:
             self.__sora()
 
         # The chain spec configs should be applied after hardcoded chain customizations above since this should override any hardcoded --chain overrides.
-        owner = c.USER if self._is_binary else c.SNAP_USER
-        spec_dir = c.CHAIN_SPEC_DIR if self._is_binary else self._snap_config.get("chain_spec_dir")
+        owner = r.user if self._is_binary else c.SNAP_USER
+        spec_dir = r.chain_spec_dir if self._is_binary else self._snap_config.get("chain_spec_dir")
         if self._chain_spec_url:
             chain_spec_path = download_chain_spec(self._chain_spec_url, "chain-spec.json", spec_dir, owner)
             self.__set_chain_name(str(chain_spec_path), 0)
@@ -155,7 +156,7 @@ class ServiceArgs:
             relay_chain_spec_path = download_chain_spec(self._local_relaychain_spec_url, "relaychain-spec.json", spec_dir, owner)
             self.__set_chain_name(str(relay_chain_spec_path), 1)
         if self._runtime_wasm_override:
-            self.__add_firstchain_args(["--wasm-runtime-overrides", c.WASM_DIR if self._is_binary else self._snap_config.get("wasm_dir")])
+            self.__add_firstchain_args(["--wasm-runtime-overrides", r.wasm_dir if self._is_binary else self._snap_config.get("wasm_dir")])
 
         # Apply --base-path whenever data-dir config parameter is set, or
         # use the snap default base path for snap workloads.

--- a/src/core/utils/binary_util.py
+++ b/src/core/utils/binary_util.py
@@ -2,10 +2,10 @@ import hashlib
 import logging
 import os
 import re
-import shutil
 import subprocess as sp
 import time
 from pathlib import Path
+from string import Template
 
 import requests
 
@@ -219,17 +219,24 @@ def get_sha256_response(sha256_url: str) -> requests.Response:
 
 def create_env_file_for_service():
     with open(f"/etc/default/{c.USER}", "w", encoding="utf-8") as f:
-        f.write(f"{c.USER.upper()}_CLI_ARGS=''")
+        f.write("POLKADOT_CLI_ARGS=''")
 
 
 def install_service_file(source_path):
     target_path = Path(f"/etc/systemd/system/{c.USER}.service")
-    shutil.copyfile(source_path, target_path)
+    service_template = Template(Path(source_path).read_text(encoding="utf-8"))
+    service_file = service_template.safe_substitute(
+        service_name=c.SERVICE_NAME,
+        binary_file=c.BINARY_FILE,
+        user=c.USER,
+        group=c.USER,
+    )
+    target_path.write_text(service_file, encoding="utf-8")
     sp.run(["systemctl", "daemon-reload"], check=False)
 
 
 def render_service_argument_file(service_args):
-    return f"{c.USER.upper()}_CLI_ARGS='{service_args}'\n"
+    return f"POLKADOT_CLI_ARGS='{service_args}'\n"
 
 
 def arguments_differ_from_disk(service_args):

--- a/src/core/utils/binary_util.py
+++ b/src/core/utils/binary_util.py
@@ -10,6 +10,7 @@ from string import Template
 import requests
 
 from core import constants as c
+from core import runtime as r
 from core.utils import general_util
 from core.utils.docker import Docker
 from core.utils.tarball import Tarball
@@ -34,7 +35,7 @@ def install_docker_runtime() -> None:
         c.DOCKER_DEAMON_CONFIG_PATH.write_text(c.DOCKER_DEAMON_JSON_CONFIG)
         sp.run(["curl", "-fsSL", "https://get.docker.com", "-o", "get-docker.sh"], check=False)
         sp.run(["sh", "get-docker.sh"], check=False)
-        sp.run(["usermod", "-aG", "docker", c.USER], check=False)
+        sp.run(["usermod", "-aG", "docker", r.user], check=False)
 
 
 def install_binary(chain_name: str, binary_url: str, binary_sha256_url: str | None = None) -> None:
@@ -66,7 +67,7 @@ def find_binary_installed_by_deb(
 
 def install_deb_from_url(url: str) -> None:
     deb_response = requests.get(url, allow_redirects=True, timeout=None)
-    deb_path = Path(c.HOME_DIR, url.split("/")[-1])
+    deb_path = Path(r.home_dir, url.split("/")[-1])
     with open(deb_path, "wb") as f:
         f.write(deb_response.content)
     package_name = sp.check_output(["dpkg-deb", "-f", deb_path, "Package"]).decode("utf-8").strip()
@@ -76,15 +77,15 @@ def install_deb_from_url(url: str) -> None:
     sp.check_call(["dpkg", "--purge", package_name])
     sp.check_call(["dpkg", "--install", deb_path])
     installed_binary = find_binary_installed_by_deb(package_name)
-    if os.path.exists(c.BINARY_FILE):
-        os.remove(c.BINARY_FILE)
-    os.symlink(installed_binary, c.BINARY_FILE)
+    if os.path.exists(r.binary_file):
+        os.remove(r.binary_file)
+    os.symlink(installed_binary, r.binary_file)
     os.remove(deb_path)
 
 
 def install_tarball_from_url(url, chain_name):
     tarball_response = requests.get(url, allow_redirects=True, timeout=None)
-    tarball_path = Path(c.HOME_DIR, url.split("/")[-1])
+    tarball_path = Path(r.home_dir, url.split("/")[-1])
     if tarball_response.status_code != 200:
         raise ValueError(f"Download binary failed with: {tarball_response.text}. Check 'binary-url'!")
 
@@ -121,28 +122,28 @@ def install_binaries_from_urls(binary_urls: str, sha256_urls: str, chain_name: s
         binary_hash = hashlib.sha256(response.content).hexdigest()
         # Get correct execute worker binary name
         if "execute-worker" in binary_url.split("/")[-1]:
-            if chain_name in c.EXECUTE_WORKER_BINARY_FILE:
-                binary_name = c.EXECUTE_WORKER_BINARY_FILE[chain_name]
+            if chain_name in r.execute_worker_binary_file:
+                binary_name = r.execute_worker_binary_file[chain_name]
             else:
-                binary_name = c.EXECUTE_WORKER_BINARY_FILE["default"]
+                binary_name = r.execute_worker_binary_file["default"]
         # Get correct prepare worker binary name
         elif "prepare-worker" in binary_url.split("/")[-1]:
-            if chain_name in c.PREPARE_WORKER_BINARY_FILE:
-                binary_name = c.PREPARE_WORKER_BINARY_FILE[chain_name]
+            if chain_name in r.prepare_worker_binary_file:
+                binary_name = r.prepare_worker_binary_file[chain_name]
             else:
-                binary_name = c.PREPARE_WORKER_BINARY_FILE["default"]
+                binary_name = r.prepare_worker_binary_file["default"]
         else:
-            binary_name = c.BINARY_FILE
+            binary_name = r.binary_file
         responses += [(binary_url, sha256_url, response, binary_name, binary_hash)]
 
     perform_sha256_checksums(responses, sha256_urls)
     stop_service()
     for binary_url, _, response, binary_name, _ in responses:
         logger.debug("Unpack binary downloaded from: %s", binary_url)
-        binary_path = c.HOME_DIR / binary_name
+        binary_path = r.home_dir / binary_name
         with open(binary_path, "wb") as f:
             f.write(response.content)
-            sp.run(["chown", f"{c.USER}:{c.USER}", binary_path], check=False)
+            sp.run(["chown", f"{r.user}:{r.user}", binary_path], check=False)
             sp.run(["chmod", "+x", binary_path], check=False)
 
 
@@ -157,25 +158,25 @@ def install_binary_from_url(url: str, sha256_url: str) -> None:
         perform_sha256_checksum(binary_hash, sha256_url)
 
     stop_service()
-    with open(c.BINARY_FILE, "wb") as f:
+    with open(r.binary_file, "wb") as f:
         f.write(binary_response.content)
-        sp.run(["chown", f"{c.USER}:{c.USER}", c.BINARY_FILE], check=False)
-        sp.run(["chmod", "+x", c.BINARY_FILE], check=False)
+        sp.run(["chown", f"{r.user}:{r.user}", r.binary_file], check=False)
+        sp.run(["chmod", "+x", r.binary_file], check=False)
 
 
 def uninstall_binary() -> None:
     if is_installed():
         if service_started():
             stop_service()
-        os.remove(c.BINARY_FILE)
-    service_file = Path(f"/etc/systemd/system/{c.SERVICE_NAME}.service")
+        os.remove(r.binary_file)
+    service_file = Path(f"/etc/systemd/system/{r.service_name}.service")
     if service_file.exists():
         os.remove(service_file)
         sp.run(["systemctl", "daemon-reload"], check=False)
 
 
 def is_installed() -> bool:
-    return c.BINARY_FILE.exists()
+    return r.binary_file.exists()
 
 
 def perform_sha256_checksums(responses: list, sha256_urls: str) -> None:
@@ -218,18 +219,18 @@ def get_sha256_response(sha256_url: str) -> requests.Response:
 
 
 def create_env_file_for_service():
-    with open(f"/etc/default/{c.USER}", "w", encoding="utf-8") as f:
+    with open(f"/etc/default/{r.user}", "w", encoding="utf-8") as f:
         f.write("POLKADOT_CLI_ARGS=''")
 
 
 def install_service_file(source_path):
-    target_path = Path(f"/etc/systemd/system/{c.USER}.service")
+    target_path = Path(f"/etc/systemd/system/{r.user}.service")
     service_template = Template(Path(source_path).read_text(encoding="utf-8"))
     service_file = service_template.safe_substitute(
-        service_name=c.SERVICE_NAME,
-        binary_file=c.BINARY_FILE,
-        user=c.USER,
-        group=c.USER,
+        service_name=r.service_name,
+        binary_file=r.binary_file,
+        user=r.user,
+        group=r.user,
     )
     target_path.write_text(service_file, encoding="utf-8")
     sp.run(["systemctl", "daemon-reload"], check=False)
@@ -241,7 +242,7 @@ def render_service_argument_file(service_args):
 
 def arguments_differ_from_disk(service_args):
     try:
-        with open(f"/etc/default/{c.USER}", "r", encoding="utf-8") as f:
+        with open(f"/etc/default/{r.user}", "r", encoding="utf-8") as f:
             args = f.read()
         return args != render_service_argument_file(service_args)
     except FileNotFoundError:
@@ -250,7 +251,7 @@ def arguments_differ_from_disk(service_args):
 
 def get_service_args() -> str:
     try:
-        command = ["cat", f"/etc/default/{c.USER}"]
+        command = ["cat", f"/etc/default/{r.user}"]
         cat_output = sp.run(command, stdout=sp.PIPE, check=False).stdout.decode("utf-8").strip()
         return cat_output.split("=")[1]  # cat:ed file includes the env variable name, which we skip including
     except Exception as e:
@@ -259,27 +260,31 @@ def get_service_args() -> str:
 
 
 def update_service_args(service_args):
-    with open(f"/etc/default/{c.USER}", "w", encoding="utf-8") as f:
+    with open(f"/etc/default/{r.user}", "w", encoding="utf-8") as f:
         f.write(render_service_argument_file(service_args))
 
 
-def is_relay_chain_node(chain_db_dir: Path = c.DB_CHAIN_DIR, relay_db_dir: Path = c.DB_RELAY_DIR) -> bool:
+def is_relay_chain_node(chain_db_dir: Path | None = None, relay_db_dir: Path | None = None) -> bool:
     return not is_parachain_node(chain_db_dir, relay_db_dir)
 
 
-def is_parachain_node(chain_db_dir: Path = c.DB_CHAIN_DIR, relay_db_dir: Path = c.DB_RELAY_DIR) -> bool:
+def is_parachain_node(chain_db_dir: Path | None = None, relay_db_dir: Path | None = None) -> bool:
+    chain_db_dir = chain_db_dir or r.db_chain_dir
+    relay_db_dir = relay_db_dir or r.db_relay_dir
     # TODO: should both of these be required to satisfy the node being a parachain, or is one enough?
     if chain_db_dir.exists() and relay_db_dir.exists():
         return True
-    if c.BINARY_FILE.exists():
-        command = rf'.{c.BINARY_FILE} --help | grep -i "\-\-collator"'
+    if r.binary_file.exists():
+        command = rf'.{r.binary_file} --help | grep -i "\-\-collator"'
         output = sp.run(command, stdout=sp.PIPE, cwd="/", shell=True, check=False)
         if output.returncode == 0:
             return True
     return False
 
 
-def get_relay_for_parachain(chain_db_dir: Path = c.DB_CHAIN_DIR, relay_db_dir: Path = c.DB_RELAY_DIR) -> str:
+def get_relay_for_parachain(chain_db_dir: Path | None = None, relay_db_dir: Path | None = None) -> str:
+    chain_db_dir = chain_db_dir or r.db_chain_dir
+    relay_db_dir = relay_db_dir or r.db_relay_dir
     if not is_parachain_node(chain_db_dir, relay_db_dir):
         return "Error, this is not a parachain"
     return general_util.get_relay_for_parachain(relay_db_dir)
@@ -289,7 +294,7 @@ def get_binary_version() -> str:
     """Returns the version of the binary client by checking the '--version' flag."""
     logger.debug("Getting binary version from client binary.")
     try:
-        command = [c.BINARY_FILE, "--version"]
+        command = [r.binary_file, "--version"]
         output = sp.run(command, stdout=sp.PIPE, check=False).stdout.decode("utf-8").strip()
         version = re.search(r"([\d.]+)", output).group(1)
         return version
@@ -298,12 +303,12 @@ def get_binary_version() -> str:
 
 
 def get_binary_md5sum() -> str:
-    return general_util.get_binary_md5sum(c.BINARY_FILE)
+    return general_util.get_binary_md5sum(r.binary_file)
 
 
 def get_binary_last_changed() -> str:
-    if c.BINARY_FILE.exists():
-        command = ["stat", c.BINARY_FILE]
+    if r.binary_file.exists():
+        command = ["stat", r.binary_file]
         stat_output = sp.run(command, stdout=sp.PIPE, check=False).stdout.decode("utf-8").strip()
         stat_split = re.split("Change: ", stat_output)[1].split(" ")
         date = stat_split[0]
@@ -313,26 +318,26 @@ def get_binary_last_changed() -> str:
 
 
 def restart_service():
-    sp.run(["systemctl", "restart", f"{c.SERVICE_NAME}.service"], check=False)
+    sp.run(["systemctl", "restart", f"{r.service_name}.service"], check=False)
 
 
 def start_service():
     # TODO: remove chown and chmod from here? Runs in the install hook already
-    sp.run(["chown", f"{c.USER}:{c.USER}", c.BINARY_FILE], check=False)
-    sp.run(["chmod", "+x", c.BINARY_FILE], check=False)
-    sp.run(["systemctl", "start", f"{c.SERVICE_NAME}.service"], check=False)
-    sp.run(["systemctl", "enable", f"{c.SERVICE_NAME}.service"], check=False)
+    sp.run(["chown", f"{r.user}:{r.user}", r.binary_file], check=False)
+    sp.run(["chmod", "+x", r.binary_file], check=False)
+    sp.run(["systemctl", "start", f"{r.service_name}.service"], check=False)
+    sp.run(["systemctl", "enable", f"{r.service_name}.service"], check=False)
 
 
 def stop_service():
-    sp.run(["systemctl", "stop", f"{c.SERVICE_NAME}.service"], check=False)
-    sp.run(["systemctl", "disable", f"{c.SERVICE_NAME}.service"], check=False)
+    sp.run(["systemctl", "stop", f"{r.service_name}.service"], check=False)
+    sp.run(["systemctl", "disable", f"{r.service_name}.service"], check=False)
 
 
 def service_started(iterations: int = 6) -> bool:
     """Checks if the service is running by running the the 'service status' command."""
     for _ in range(iterations):
-        service_status = os.system(f"service {c.SERVICE_NAME} status")
+        service_status = os.system(f"service {r.service_name} status")
         if service_status == 0:
             return True
         if iterations > 1:
@@ -341,38 +346,40 @@ def service_started(iterations: int = 6) -> bool:
 
 
 def generate_node_key():
-    if c.BINARY_FILE.exists():
-        command = [c.BINARY_FILE, "key", "generate-node-key", "--file", c.NODE_KEY_FILE]
+    if r.binary_file.exists():
+        command = [r.binary_file, "key", "generate-node-key", "--file", r.node_key_file]
 
         # This is to make it work on Enjin relay deployments
         logger.debug("Getting binary version from client binary to check if it is Enjin.")
-        get_version_command = [c.BINARY_FILE, "--version"]
+        get_version_command = [r.binary_file, "--version"]
         output = sp.run(get_version_command, stdout=sp.PIPE, check=False).stdout.decode("utf-8").strip().lower()
         if "enjin" in output:
             command += ["--chain", "enjin"]
 
         sp.run(command, check=False)
-        sp.run(["chown", f"{c.USER}:{c.USER}", c.NODE_KEY_FILE], check=False)
-        sp.run(["chmod", "0600", c.NODE_KEY_FILE], check=False)
+        sp.run(["chown", f"{r.user}:{r.user}", r.node_key_file], check=False)
+        sp.run(["chmod", "0600", r.node_key_file], check=False)
     else:
         raise ValueError("No binary file found to generate node key. Please check your configuration.")
 
 
-def get_chain_disk_usage(chain_db_dir: Path = c.DB_CHAIN_DIR) -> str:
+def get_chain_disk_usage(chain_db_dir: Path | None = None) -> str:
+    chain_db_dir = chain_db_dir or r.db_chain_dir
     if chain_db_dir.exists():
         return general_util.get_disk_usage(chain_db_dir)
     return ""
 
 
-def get_relay_disk_usage(relay_db_dir: Path = c.DB_RELAY_DIR) -> str:
+def get_relay_disk_usage(relay_db_dir: Path | None = None) -> str:
+    relay_db_dir = relay_db_dir or r.db_relay_dir
     if relay_db_dir.exists():
         return general_util.get_disk_usage(relay_db_dir)
     return ""
 
 
 def get_client_binary_help_output() -> str:
-    if c.BINARY_FILE.exists():
-        command = f".{c.BINARY_FILE} --help"
+    if r.binary_file.exists():
+        command = f".{r.binary_file} --help"
         process = sp.run(command, stdout=sp.PIPE, cwd="/", shell=True, check=False)
         if process.returncode == 0:
             return process.stdout.decode("utf-8").strip()
@@ -381,4 +388,4 @@ def get_client_binary_help_output() -> str:
 
 
 def get_binary_path() -> str:
-    return str(c.BINARY_FILE)
+    return str(r.binary_file)

--- a/src/core/utils/docker.py
+++ b/src/core/utils/docker.py
@@ -88,13 +88,13 @@ class Docker:
         except sp.CalledProcessError as err:
             raise ValueError(f"Could not pull {docker_image_and_tag} check 'docker-tag'!") from err
 
-        sp.run(["docker", "create", "--name", "tmp", docker_image_and_tag], check=False)
+        sp.run(["docker", "create", "--name", c.DOCKER_CONTAINER_NAME, docker_image_and_tag], check=False)
         try:
-            sp.run(["docker", "cp", f"tmp:{docker_binary_path}", c.BINARY_FILE], check=True)
+            sp.run(["docker", "cp", f"{c.DOCKER_CONTAINER_NAME}:{docker_binary_path}", c.BINARY_FILE], check=True)
         except sp.CalledProcessError as err:
             raise ValueError(f"Could not find {docker_binary_path} in {docker_image_and_tag} check that it really exist in the image!") from err
         if docker_specs_path:
-            sp.run(["docker", "cp", f"tmp:{docker_specs_path}", c.HOME_DIR], check=True)
-            sp.run(["chown", "-R", "polkadot:polkadot", Path(c.HOME_DIR, Path(docker_specs_path).name)], check=True)
-        sp.run(["docker", "rm", "tmp"], check=True)
+            sp.run(["docker", "cp", f"{c.DOCKER_CONTAINER_NAME}:{docker_specs_path}", c.HOME_DIR], check=True)
+            sp.run(["chown", "-R", f"{c.USER}:{c.USER}", Path(c.HOME_DIR, Path(docker_specs_path).name)], check=True)
+        sp.run(["docker", "rm", c.DOCKER_CONTAINER_NAME], check=True)
         sp.run(["docker", "rmi", docker_image_and_tag], check=True)

--- a/src/core/utils/docker.py
+++ b/src/core/utils/docker.py
@@ -4,7 +4,7 @@ import logging
 import subprocess as sp
 from pathlib import Path
 
-import core.constants as c
+from core import runtime as r
 
 logger = logging.getLogger(__name__)
 
@@ -88,13 +88,13 @@ class Docker:
         except sp.CalledProcessError as err:
             raise ValueError(f"Could not pull {docker_image_and_tag} check 'docker-tag'!") from err
 
-        sp.run(["docker", "create", "--name", c.DOCKER_CONTAINER_NAME, docker_image_and_tag], check=False)
+        sp.run(["docker", "create", "--name", r.docker_container_name, docker_image_and_tag], check=False)
         try:
-            sp.run(["docker", "cp", f"{c.DOCKER_CONTAINER_NAME}:{docker_binary_path}", c.BINARY_FILE], check=True)
+            sp.run(["docker", "cp", f"{r.docker_container_name}:{docker_binary_path}", r.binary_file], check=True)
         except sp.CalledProcessError as err:
             raise ValueError(f"Could not find {docker_binary_path} in {docker_image_and_tag} check that it really exist in the image!") from err
         if docker_specs_path:
-            sp.run(["docker", "cp", f"{c.DOCKER_CONTAINER_NAME}:{docker_specs_path}", c.HOME_DIR], check=True)
-            sp.run(["chown", "-R", f"{c.USER}:{c.USER}", Path(c.HOME_DIR, Path(docker_specs_path).name)], check=True)
-        sp.run(["docker", "rm", c.DOCKER_CONTAINER_NAME], check=True)
+            sp.run(["docker", "cp", f"{r.docker_container_name}:{docker_specs_path}", r.home_dir], check=True)
+            sp.run(["chown", "-R", f"{r.user}:{r.user}", Path(r.home_dir, Path(docker_specs_path).name)], check=True)
+        sp.run(["docker", "rm", r.docker_container_name], check=True)
         sp.run(["docker", "rmi", docker_image_and_tag], check=True)

--- a/src/core/utils/tarball.py
+++ b/src/core/utils/tarball.py
@@ -1,7 +1,7 @@
 import subprocess as sp
 from tarfile import open as open_tarfile
 
-import core.constants as c
+from core import runtime as r
 
 
 class Tarball:
@@ -16,10 +16,10 @@ class Tarball:
             if "data-avail" in tarball.getnames():
                 member = tarball.getmember("data-avail")
                 if member.isfile():
-                    tarball.extract(member, path=c.HOME_DIR)
-                    sp.run(["mv", c.HOME_DIR / "data-avail", c.BINARY_FILE, "--force"])
+                    tarball.extract(member, path=r.home_dir)
+                    sp.run(["mv", r.home_dir / "data-avail", r.binary_file, "--force"])
                     sp.run(["rm", self.tarball_path])
-                    sp.run(["chown", f"{c.USER}:{c.USER}", c.BINARY_FILE])
+                    sp.run(["chown", f"{r.user}:{r.user}", r.binary_file])
                 else:
                     raise ValueError("Expected client binary 'data-avail' in tarball is not a file.")
             else:

--- a/src/core/utils/user_group_util.py
+++ b/src/core/utils/user_group_util.py
@@ -1,10 +1,10 @@
 import subprocess as sp
 
-from core import constants as c
+from core import runtime as r
 
 
 def setup_group_and_user():
-    sp.run(["addgroup", "--system", c.USER], check=False)
-    sp.run(["adduser", "--system", "--home", c.HOME_DIR, "--disabled-password", "--ingroup", c.USER, c.USER], check=False)
-    sp.run(["chown", f"{c.USER}:{c.USER}", c.HOME_DIR], check=False)
-    sp.run(["chmod", "700", c.HOME_DIR], check=False)
+    sp.run(["addgroup", "--system", r.user], check=False)
+    sp.run(["adduser", "--system", "--home", r.home_dir, "--disabled-password", "--ingroup", r.user, r.user], check=False)
+    sp.run(["chown", f"{r.user}:{r.user}", r.home_dir], check=False)
+    sp.run(["chmod", "700", r.home_dir], check=False)

--- a/src/interface_prometheus.py
+++ b/src/interface_prometheus.py
@@ -95,3 +95,8 @@ class PrometheusProvider(Object):
         job = json.dumps(self._job(str(bind_address)), sort_keys=True)
         for relation in self.model.relations[self._relation_name]:
             relation.data[self.model.unit][f"request_{self._request_id}"] = job
+
+    def set_port(self, port):
+        """Update the advertised scrape port and republish relation data."""
+        self._port = str(port)
+        self.set_job()

--- a/src/migrators/data_migrator.py
+++ b/src/migrators/data_migrator.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Tuple
 
 from core import constants as c
+from core import runtime as r
 
 logger = logging.getLogger(__name__)
 
@@ -33,12 +34,12 @@ class DataMigrator:
             snap_name: Name of the snap (optional)
         """
 
-        if snap_name not in c.SNAP_CONFIG:
-            raise ValueError(f"Invalid snap_name '{snap_name}'. Valid options are: {list(c.SNAP_CONFIG.keys())}")
+        if snap_name not in r.snap_config:
+            raise ValueError(f"Invalid snap_name '{snap_name}'. Valid options are: {list(r.snap_config.keys())}")
 
         # Normal migration from legacy to snap
-        self.src_path = c.BASE_PATH
-        self.dest_path = Path(c.SNAP_CONFIG.get(snap_name).get("base_path"))
+        self.src_path = r.base_path
+        self.dest_path = Path(r.snap_config.get(snap_name).get("base_path"))
 
         if reverse:
             # If reverse is True, swap the paths
@@ -257,8 +258,8 @@ class DataMigrator:
             # Ensure permissions and ownership
             if self.dest_path.is_relative_to("/var/snap/"):
                 subprocess.run(["chown", "-R", f"{c.SNAP_USER}:{c.SNAP_USER}", str(self.dest_path)])
-            elif self.dest_path.is_relative_to(c.HOME_DIR):
-                subprocess.run(["chown", "-R", f"{c.USER}:{c.USER}", f"{c.HOME_DIR.joinpath('.local')}"])
+            elif self.dest_path.is_relative_to(r.home_dir):
+                subprocess.run(["chown", "-R", f"{r.user}:{r.user}", f"{r.home_dir.joinpath('.local')}"])
 
             result.update({"success": True, "method": method, "source_info": source_info, "destination_info": self.get_directory_info(self.dest_path)})
 
@@ -404,8 +405,8 @@ def migrate_data(snap_name: str, dry_run: bool, reverse: bool) -> None:
     If src is None, the data is not migrated.
     If dest is None, the data is not migrated.
     """
-    if not snap_name or snap_name not in c.SNAP_CONFIG:
-        message = f"Invalid or missing 'snap-name' parameter for migration operation. The snap-name must be one of the supported applications: {', '.join(c.SNAP_CONFIG.keys())}. Please specify a valid snap name to proceed with the migration."
+    if not snap_name or snap_name not in r.snap_config:
+        message = f"Invalid or missing 'snap-name' parameter for migration operation. The snap-name must be one of the supported applications: {', '.join(r.snap_config.keys())}. Please specify a valid snap name to proceed with the migration."
         logger.error(message)
         raise ValueError(message)
 

--- a/src/migrators/data_migrator.py
+++ b/src/migrators/data_migrator.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Tuple
 
 from core import constants as c
-from core.constants import SNAP_CONFIG
 
 logger = logging.getLogger(__name__)
 
@@ -27,9 +26,6 @@ class DataMigrationError(Exception):
 class DataMigrator:
     """Handles migration of Polkadot data from legacy location to snap common directory."""
 
-    # Default paths
-    LEGACY_DATA_DIR = Path("/home/polkadot/.local/share/polkadot")
-
     def __init__(self, snap_name: str = None, reverse: bool = False):
         """Initialize the data migrator.
 
@@ -37,12 +33,12 @@ class DataMigrator:
             snap_name: Name of the snap (optional)
         """
 
-        if snap_name not in SNAP_CONFIG:
-            raise ValueError(f"Invalid snap_name '{snap_name}'. Valid options are: {list(SNAP_CONFIG.keys())}")
+        if snap_name not in c.SNAP_CONFIG:
+            raise ValueError(f"Invalid snap_name '{snap_name}'. Valid options are: {list(c.SNAP_CONFIG.keys())}")
 
         # Normal migration from legacy to snap
-        self.src_path = self.LEGACY_DATA_DIR
-        self.dest_path = Path(SNAP_CONFIG.get(snap_name).get("base_path"))
+        self.src_path = c.BASE_PATH
+        self.dest_path = Path(c.SNAP_CONFIG.get(snap_name).get("base_path"))
 
         if reverse:
             # If reverse is True, swap the paths
@@ -408,8 +404,8 @@ def migrate_data(snap_name: str, dry_run: bool, reverse: bool) -> None:
     If src is None, the data is not migrated.
     If dest is None, the data is not migrated.
     """
-    if not snap_name or snap_name not in SNAP_CONFIG:
-        message = f"Invalid or missing 'snap-name' parameter for migration operation. The snap-name must be one of the supported applications: {', '.join(SNAP_CONFIG.keys())}. Please specify a valid snap name to proceed with the migration."
+    if not snap_name or snap_name not in c.SNAP_CONFIG:
+        message = f"Invalid or missing 'snap-name' parameter for migration operation. The snap-name must be one of the supported applications: {', '.join(c.SNAP_CONFIG.keys())}. Please specify a valid snap name to proceed with the migration."
         logger.error(message)
         raise ValueError(message)
 

--- a/src/migrators/node_key_migrator.py
+++ b/src/migrators/node_key_migrator.py
@@ -2,6 +2,7 @@ import logging
 import shutil
 
 import core.constants as c
+from core import runtime as r
 
 logger = logging.getLogger(__name__)
 
@@ -11,20 +12,20 @@ def migrate_node_key(snap_name: str, dry_run: bool = False, reverse: bool = Fals
     Migrate the node key from the old location to the new location.
     """
 
-    if not snap_name or snap_name not in c.SNAP_CONFIG:
-        message = f"Invalid or missing 'snap-name' parameter for migration operation. The snap-name must be one of the supported applications: {', '.join(c.SNAP_CONFIG.keys())}. Please specify a valid snap name to proceed with the migration."
+    if not snap_name or snap_name not in r.snap_config:
+        message = f"Invalid or missing 'snap-name' parameter for migration operation. The snap-name must be one of the supported applications: {', '.join(r.snap_config.keys())}. Please specify a valid snap name to proceed with the migration."
         logger.error(message)
         raise ValueError(message)
 
     # Normal migration from legacy to snap
-    src_path = c.NODE_KEY_FILE
-    dest_path = c.SNAP_CONFIG.get(snap_name).get("node_key_file")
+    src_path = r.node_key_file
+    dest_path = r.snap_config.get(snap_name).get("node_key_file")
     owner = c.SNAP_USER
 
     if reverse:
         # If reverse is True, swap the paths
         src_path, dest_path = dest_path, src_path
-        owner = c.USER
+        owner = r.user
 
     if not src_path.exists():
         logger.info("No node key found to migrate.")

--- a/templates/etc/systemd/system/polkadot.service
+++ b/templates/etc/systemd/system/polkadot.service
@@ -4,10 +4,10 @@ After=network.target
 Documentation=https://github.com/paritytech/polkadot
 
 [Service]
-EnvironmentFile=-/etc/default/polkadot
-ExecStart=/home/polkadot/polkadot $POLKADOT_CLI_ARGS
-User=polkadot
-Group=polkadot
+EnvironmentFile=-/etc/default/${service_name}
+ExecStart=${binary_file} $$POLKADOT_CLI_ARGS
+User=${user}
+Group=${group}
 Restart=always
 RestartSec=120
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -19,6 +19,7 @@ from charms.dwellir_observability.v0.machine_observability import (  # noqa: E40
 )
 
 from charm import PolkadotCharm  # noqa: E402
+from core.service_args import ServiceArgs  # noqa: E402
 
 
 def test_has_valid_client_config_allows_single_source():
@@ -93,6 +94,16 @@ def test_machine_observability_payload_serializes_to_relation_shape():
     }
 
 
+def test_machine_observability_payload_serializes_custom_metrics_port():
+    payload = build_machine_observability_payload(
+        service_name="snap.polkadot.polkadot.service",
+        charm_name="polkadot",
+        metrics_port="19615",
+    )
+
+    assert payload.metrics_endpoints[0].targets == ["localhost:19615"]
+
+
 def test_machine_observability_payload_serializes_to_v2_relation_shape():
     payload = build_machine_observability_payload(
         service_name="snap.polkadot.polkadot.service",
@@ -137,6 +148,7 @@ def test_publish_machine_observability_uses_charm_metadata_and_runtime_service_n
 
     charm = SimpleNamespace(
         config={
+            "service-args": "",
             "snap-name": "",
         },
         _stored=SimpleNamespace(snap_name=None),
@@ -161,6 +173,7 @@ def test_publish_machine_observability_uses_snap_service_name_when_snap_configur
 
     charm = SimpleNamespace(
         config={
+            "service-args": "",
             "snap-name": "polkadot",
         },
         _stored=SimpleNamespace(snap_name=None),
@@ -180,7 +193,7 @@ def test_publish_machine_observability_uses_snap_service_name_when_snap_configur
 
 def test_build_machine_observability_payload_uses_snap_service_name_when_configured():
     charm = SimpleNamespace(
-        config={"snap-name": "polkadot"},
+        config={"service-args": "", "snap-name": "polkadot"},
         _stored=SimpleNamespace(snap_name=None),
         meta=SimpleNamespace(name="polkadot"),
         app=SimpleNamespace(name="polkadot"),
@@ -197,3 +210,45 @@ def test_build_machine_observability_payload_uses_snap_service_name_when_configu
     assert payload.source_topology.application == "polkadot"
     assert payload.source_topology.unit == "polkadot/0"
     assert payload.systemd_units == ["snap.polkadot.polkadot.service"]
+
+
+def test_build_machine_observability_payload_uses_snap_instance_name_when_configured():
+    charm = SimpleNamespace(
+        app=SimpleNamespace(name="foo-bar"),
+        config={
+            "service-args": "--chain polkadot --rpc-port 9933 --prometheus-port 19615",
+            "snap-name": "polkadot",
+        },
+        _stored=SimpleNamespace(snap_name=None),
+        meta=SimpleNamespace(name="polkadot"),
+        model=SimpleNamespace(name="test-model", uuid="test-uuid"),
+        unit=SimpleNamespace(name="foo-bar/0"),
+    )
+    charm._source_topology = lambda: PolkadotCharm._source_topology(charm)
+
+    payload = PolkadotCharm._build_machine_observability_payload(charm)
+
+    assert payload.systemd_units == ["snap.polkadot_db7329d5a3.polkadot.service"]
+    assert payload.source_topology.application == "foo-bar"
+    assert payload.metrics_endpoints[0].targets == ["localhost:19615"]
+
+
+def test_prometheus_port():
+    cases = [
+        ("--chain polkadot --rpc-port 9933", "9615"),
+        ("--chain polkadot --rpc-port 9933 --prometheus-port 19615", "19615"),
+        ("--chain=polkadot --rpc-port=9933 --prometheus-port=19616", "19616"),
+    ]
+
+    for service_args, expected in cases:
+        config = {
+            "service-args": service_args,
+            "data-dir": "",
+            "chain-spec-url": "",
+            "local-relaychain-spec-url": "",
+            "wasm-runtime-url": "",
+            "docker-tag": "",
+            "binary-url": "",
+            "snap-name": "polkadot",
+        }
+        assert ServiceArgs(config, {}).prometheus_port == expected

--- a/tests/unit/test_runtime_identity.py
+++ b/tests/unit/test_runtime_identity.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from charms.operator_libs_linux.v2 import snap
 
 from core import constants as c
+from core import runtime as r
 from core.utils import binary_util
 
 
@@ -12,6 +13,28 @@ def test_constants_module_contains_no_functions():
     functions = [name for name, value in inspect.getmembers(c, inspect.isfunction) if getattr(value, "__module__", "") == c.__name__]
 
     assert functions == []
+
+
+def test_constants_module_does_not_contain_runtime_identity_state():
+    runtime_state_names = {
+        "USER",
+        "SERVICE_NAME",
+        "HOME_DIR",
+        "BASE_PATH",
+        "BINARY_FILE",
+        "EXECUTE_WORKER_BINARY_FILE",
+        "PREPARE_WORKER_BINARY_FILE",
+        "CHAIN_SPEC_DIR",
+        "NODE_KEY_FILE",
+        "DB_CHAIN_DIR",
+        "DB_RELAY_DIR",
+        "WASM_DIR",
+        "SNAP_INSTANCE_KEY",
+        "SNAP_CONFIG",
+        "DOCKER_CONTAINER_NAME",
+    }
+
+    assert runtime_state_names.isdisjoint(dir(c))
 
 
 def test_runtime_identity_does_not_duplicate_base_snap_config():
@@ -46,14 +69,14 @@ Group=${group}
         )
         monkeypatch.setattr(binary_util.sp, "run", lambda *args, **kwargs: None)
 
-        assert c.USER == "foo-bar"
-        assert c.SERVICE_NAME == "foo-bar"
-        assert c.HOME_DIR.as_posix() == "/home/foo-bar"
-        assert c.BASE_PATH.as_posix() == "/home/foo-bar/.local/share/polkadot"
-        assert c.BINARY_FILE.as_posix() == "/home/foo-bar/polkadot"
-        assert c.NODE_KEY_FILE.as_posix() == "/home/foo-bar/node-key"
-        assert c.WASM_DIR.as_posix() == "/home/foo-bar/wasm"
-        assert c.DOCKER_CONTAINER_NAME == "foo-bar-install-tmp"
+        assert r.user == "foo-bar"
+        assert r.service_name == "foo-bar"
+        assert r.home_dir.as_posix() == "/home/foo-bar"
+        assert r.base_path.as_posix() == "/home/foo-bar/.local/share/polkadot"
+        assert r.binary_file.as_posix() == "/home/foo-bar/polkadot"
+        assert r.node_key_file.as_posix() == "/home/foo-bar/node-key"
+        assert r.wasm_dir.as_posix() == "/home/foo-bar/wasm"
+        assert r.docker_container_name == "foo-bar-install-tmp"
 
         binary_util.install_service_file(service_template_path)
         service_file = installed_service_path.read_text(encoding="utf-8")
@@ -74,11 +97,11 @@ def test_runtime_identity_uses_sha1_snap_instance_key():
     try:
         runtime_identity.configure_runtime_identity(app_name)
 
-        assert c.SNAP_INSTANCE_KEY == instance_key
-        assert c.SNAP_CONFIG["polkadot"]["snap_name"] == f"polkadot_{instance_key}"
-        assert c.SNAP_CONFIG["polkadot"]["base_path"].as_posix() == f"/var/snap/polkadot_{instance_key}/common/polkadot_base"
-        assert c.SNAP_CONFIG["polkadot"]["cli_command"] == f"polkadot_{instance_key}.polkadot-cli"
-        assert c.SNAP_CONFIG["polkadot"]["systemd_service"] == f"snap.polkadot_{instance_key}.polkadot.service"
+        assert r.snap_instance_key == instance_key
+        assert r.snap_config["polkadot"]["snap_name"] == f"polkadot_{instance_key}"
+        assert r.snap_config["polkadot"]["base_path"].as_posix() == f"/var/snap/polkadot_{instance_key}/common/polkadot_base"
+        assert r.snap_config["polkadot"]["cli_command"] == f"polkadot_{instance_key}.polkadot-cli"
+        assert r.snap_config["polkadot"]["systemd_service"] == f"snap.polkadot_{instance_key}.polkadot.service"
     finally:
         runtime_identity.configure_runtime_identity("polkadot")
 
@@ -89,10 +112,10 @@ def test_default_runtime_identity_keeps_non_parallel_snap_names():
     try:
         runtime_identity.configure_runtime_identity("polkadot")
 
-        assert c.SNAP_INSTANCE_KEY == ""
-        assert c.SNAP_CONFIG["polkadot"]["snap_name"] == "polkadot"
-        assert c.SNAP_CONFIG["polkadot"]["cli_command"] == "polkadot.polkadot-cli"
-        assert c.SNAP_CONFIG["polkadot"]["systemd_service"] == "snap.polkadot.polkadot.service"
+        assert r.snap_instance_key == ""
+        assert r.snap_config["polkadot"]["snap_name"] == "polkadot"
+        assert r.snap_config["polkadot"]["cli_command"] == "polkadot.polkadot-cli"
+        assert r.snap_config["polkadot"]["systemd_service"] == "snap.polkadot.polkadot.service"
     finally:
         runtime_identity.configure_runtime_identity("polkadot")
 

--- a/tests/unit/test_runtime_identity.py
+++ b/tests/unit/test_runtime_identity.py
@@ -1,0 +1,130 @@
+import hashlib
+import inspect
+from types import SimpleNamespace
+
+from charms.operator_libs_linux.v2 import snap
+
+from core import constants as c
+from core.utils import binary_util
+
+
+def test_constants_module_contains_no_functions():
+    functions = [name for name, value in inspect.getmembers(c, inspect.isfunction) if getattr(value, "__module__", "") == c.__name__]
+
+    assert functions == []
+
+
+def test_runtime_identity_does_not_duplicate_base_snap_config():
+    from core import runtime_identity
+
+    assert not hasattr(runtime_identity, "BASE_SNAP_CONFIG")
+    assert "polkadot" in c.DEFAULT_SNAP_CONFIG
+    assert "polkadot-parachain" in c.DEFAULT_SNAP_CONFIG
+
+
+def test_runtime_identity_uses_application_name_for_binary_resources(tmp_path, monkeypatch):
+    from core import runtime_identity
+
+    try:
+        runtime_identity.configure_runtime_identity("foo-bar")
+        service_template_path = tmp_path / "polkadot.service"
+        service_template_path.write_text(
+            """[Unit]
+EnvironmentFile=-/etc/default/${service_name}
+ExecStart=${binary_file} $$POLKADOT_CLI_ARGS
+User=${user}
+Group=${group}
+""",
+            encoding="utf-8",
+        )
+        installed_service_path = tmp_path / "foo-bar.service"
+        real_path = binary_util.Path
+        monkeypatch.setattr(
+            binary_util,
+            "Path",
+            lambda *args: installed_service_path if args == ("/etc/systemd/system/foo-bar.service",) else real_path(*args),
+        )
+        monkeypatch.setattr(binary_util.sp, "run", lambda *args, **kwargs: None)
+
+        assert c.USER == "foo-bar"
+        assert c.SERVICE_NAME == "foo-bar"
+        assert c.HOME_DIR.as_posix() == "/home/foo-bar"
+        assert c.BASE_PATH.as_posix() == "/home/foo-bar/.local/share/polkadot"
+        assert c.BINARY_FILE.as_posix() == "/home/foo-bar/polkadot"
+        assert c.NODE_KEY_FILE.as_posix() == "/home/foo-bar/node-key"
+        assert c.WASM_DIR.as_posix() == "/home/foo-bar/wasm"
+        assert c.DOCKER_CONTAINER_NAME == "foo-bar-install-tmp"
+
+        binary_util.install_service_file(service_template_path)
+        service_file = installed_service_path.read_text(encoding="utf-8")
+        assert "EnvironmentFile=-/etc/default/foo-bar" in service_file
+        assert "ExecStart=/home/foo-bar/polkadot $POLKADOT_CLI_ARGS" in service_file
+        assert "User=foo-bar" in service_file
+        assert "Group=foo-bar" in service_file
+    finally:
+        runtime_identity.configure_runtime_identity("polkadot")
+
+
+def test_runtime_identity_uses_sha1_snap_instance_key():
+    from core import runtime_identity
+
+    app_name = "foo-bar-and-something-more"
+    instance_key = hashlib.sha1(app_name.encode("utf-8")).hexdigest()[:10]
+
+    try:
+        runtime_identity.configure_runtime_identity(app_name)
+
+        assert c.SNAP_INSTANCE_KEY == instance_key
+        assert c.SNAP_CONFIG["polkadot"]["snap_name"] == f"polkadot_{instance_key}"
+        assert c.SNAP_CONFIG["polkadot"]["base_path"].as_posix() == f"/var/snap/polkadot_{instance_key}/common/polkadot_base"
+        assert c.SNAP_CONFIG["polkadot"]["cli_command"] == f"polkadot_{instance_key}.polkadot-cli"
+        assert c.SNAP_CONFIG["polkadot"]["systemd_service"] == f"snap.polkadot_{instance_key}.polkadot.service"
+    finally:
+        runtime_identity.configure_runtime_identity("polkadot")
+
+
+def test_default_runtime_identity_keeps_non_parallel_snap_names():
+    from core import runtime_identity
+
+    try:
+        runtime_identity.configure_runtime_identity("polkadot")
+
+        assert c.SNAP_INSTANCE_KEY == ""
+        assert c.SNAP_CONFIG["polkadot"]["snap_name"] == "polkadot"
+        assert c.SNAP_CONFIG["polkadot"]["cli_command"] == "polkadot.polkadot-cli"
+        assert c.SNAP_CONFIG["polkadot"]["systemd_service"] == "snap.polkadot.polkadot.service"
+    finally:
+        runtime_identity.configure_runtime_identity("polkadot")
+
+
+def test_snap_manager_bootstraps_missing_parallel_instance_from_base_snap(monkeypatch):
+    from core import runtime_identity
+    from core.managers.polkadot_snap import PolkadotSnapManager
+
+    class FakeSnapCache:
+        def __getitem__(self, snap_name):
+            if snap_name == "polkadot_db7329d5a3":
+                raise snap.SnapNotFoundError("missing instance")
+            if snap_name == "polkadot":
+                return SimpleNamespace(
+                    channel="latest/stable",
+                    revision="123",
+                    confinement="strict",
+                )
+            raise AssertionError(f"unexpected snap lookup: {snap_name}")
+
+    try:
+        runtime_identity.configure_runtime_identity("foo-bar")
+        monkeypatch.setattr(snap, "SnapCache", FakeSnapCache)
+        monkeypatch.setattr(PolkadotSnapManager, "_enable_parallel_instances", lambda self: None)
+
+        manager = PolkadotSnapManager()
+        manager.configure(snap_name="polkadot", data_dir="")
+
+        assert manager._polkadot_snap.name == "polkadot_db7329d5a3"
+        assert manager._polkadot_snap.state is snap.SnapState.Available
+        assert manager._polkadot_snap.channel == "latest/stable"
+        assert manager._polkadot_snap.revision == "123"
+        assert manager._polkadot_snap.confinement == "strict"
+    finally:
+        runtime_identity.configure_runtime_identity("polkadot")


### PR DESCRIPTION
Changes to enable us to deploy multiple polkadot on the same machine.
* The juju application name will be used for this. Since application names in a model must be unique, this should work. Deploying without setting one will work as before, i.e. `polkadot` is used.
* When a custom application name is used, that name, e.g. `foo-bar`, will be used for:
  * `/home/foo-bar/`
  * `/etc/systemd/system/foo-bar.service` and `/etc/default/foo-bar`
  * snap instance name `polkadot_<sha1_of_foo-bar>[:10]`. Using the 10 first chars of the sha1 instead of the actual name is due to snap naming limitations.
* Possibility to set the prometheus metrics port to avoid port conflict