### PR TITLE
Downloading chain spec only when actually needed.

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -25,7 +25,7 @@ from core import runtime as r
 from core import runtime_identity
 from core.managers import PolkadotSnapManager, WorkloadFactory, WorkloadType
 from core.service_args import ServiceArgs
-from core.utils import general_util, user_group_util
+from core.utils import download_util, general_util, user_group_util
 from interface_prometheus import PrometheusProvider
 from interface_rpc_url_provider import RpcUrlProvider
 from interface_rpc_url_requirer import RpcUrlRequirer
@@ -159,6 +159,7 @@ class PolkadotCharm(ops.CharmBase):
         if self.config.get("wasm-runtime-url"):
             self._workload.download_wasm_runtime(self.config.get("wasm-runtime-url"))
 
+        self._download_configured_chain_specs()
         self._workload.generate_node_key()
         self._workload.set_service_args(service_args_obj.service_args_string)
         self._stored.initial_start_pending = True
@@ -191,6 +192,9 @@ class PolkadotCharm(ops.CharmBase):
         # Only restart when this hook actually changes runtime inputs.
         was_running = self._workload.is_service_running()
         should_restart = False
+        # Target changes cover rare binary/snap and snap-name moves where the same URL
+        # must be written to a new local path.
+        chain_spec_target_changed = False
 
         # NB: The install operation would stop the service if it's running.
         # The caller is responsible for restarting the service afterwards.
@@ -212,6 +216,7 @@ class PolkadotCharm(ops.CharmBase):
                         self.unit.status = ops.MaintenanceStatus("Installing binary")
                         self._workload = WorkloadFactory.BINARY_MANAGER
                         restart_after_install = False
+                        chain_spec_target_changed = True
                     else:
                         self.unit.status = ops.MaintenanceStatus("Updating binary")
                     self._workload.configure(
@@ -231,6 +236,7 @@ class PolkadotCharm(ops.CharmBase):
                         self.unit.status = ops.MaintenanceStatus("Installing Snap")
                         self._workload = WorkloadFactory.SNAP_MANAGER
                         restart_after_install = False
+                        chain_spec_target_changed = True
                     self._workload.configure(
                         channel=self.config.get("snap-channel"),
                         revision=self.config.get("snap-revision"),
@@ -287,6 +293,7 @@ class PolkadotCharm(ops.CharmBase):
         if self._stored.chain_spec_url != self.config.get("chain-spec-url"):
             try:
                 self.unit.status = ops.MaintenanceStatus("Updating chain spec")
+                self._download_configured_chain_specs(chain_spec=True, local_relaychain_spec=False)
                 self._workload.set_service_args(service_args_obj.service_args_string)
                 self._stored.chain_spec_url = self.config.get("chain-spec-url")
                 should_restart = was_running
@@ -298,6 +305,7 @@ class PolkadotCharm(ops.CharmBase):
         if self._stored.local_relaychain_spec_url != self.config.get("local-relaychain-spec-url"):
             try:
                 self.unit.status = ops.MaintenanceStatus("Updating relaychain spec")
+                self._download_configured_chain_specs(chain_spec=False, local_relaychain_spec=True)
                 self._workload.set_service_args(service_args_obj.service_args_string)
                 self._stored.local_relaychain_spec_url = self.config.get("local-relaychain-spec-url")
                 should_restart = was_running
@@ -359,11 +367,23 @@ class PolkadotCharm(ops.CharmBase):
                     )
                     self._workload.install()
                     self._stored.snap_name = self.config.get("snap-name")
+                    chain_spec_target_changed = True
                     logger.info(f"Snap name changed to {self.config.get('snap-name')} successfully")
                 except ValueError as e:
                     self.unit.status = ops.BlockedStatus(str(e))
                     event.defer()
                     return
+
+        if chain_spec_target_changed and (self.config.get("chain-spec-url") or self.config.get("local-relaychain-spec-url")):
+            try:
+                self.unit.status = ops.MaintenanceStatus("Updating chain spec")
+                self._download_configured_chain_specs()
+                self._workload.set_service_args(service_args_obj.service_args_string)
+                should_restart = was_running
+            except ValueError as e:
+                self.unit.status = ops.BlockedStatus(str(e))
+                event.defer()
+                return
 
         if self._workload.service_args_differ_from_disk(service_args_obj.service_args_string):
             self._workload.set_service_args(service_args_obj.service_args_string)
@@ -384,6 +404,20 @@ class PolkadotCharm(ops.CharmBase):
         self.cos_agent_provider._metrics_endpoints = [{"port": int(metrics_port), "path": "/metrics"}]
         self.cos_agent_provider._on_refresh(None)
         self._publish_machine_observability()
+
+    def _chain_spec_download_context(self):
+        if self._workload.get_type() == WorkloadType.BINARY:
+            return r.chain_spec_dir, r.user
+
+        snap_name = self.config.get("snap-name") or self._stored.snap_name
+        return r.snap_config[snap_name]["chain_spec_dir"], c.SNAP_USER
+
+    def _download_configured_chain_specs(self, chain_spec: bool = True, local_relaychain_spec: bool = True) -> None:
+        spec_dir, owner = self._chain_spec_download_context()
+        if chain_spec and self.config.get("chain-spec-url"):
+            download_util.download_chain_spec(self.config.get("chain-spec-url"), "chain-spec.json", spec_dir, owner)
+        if local_relaychain_spec and self.config.get("local-relaychain-spec-url"):
+            download_util.download_chain_spec(self.config.get("local-relaychain-spec-url"), "relaychain-spec.json", spec_dir, owner)
 
     def _on_update_status(self, event: ops.UpdateStatusEvent) -> None:
         self._publish_machine_observability()

--- a/src/core/service_args.py
+++ b/src/core/service_args.py
@@ -6,7 +6,6 @@ from ops.model import ConfigData
 
 import core.constants as c
 from core import runtime as r
-from core.utils.download_util import download_chain_spec
 
 
 class ServiceArgs:
@@ -147,13 +146,12 @@ class ServiceArgs:
             self.__sora()
 
         # The chain spec configs should be applied after hardcoded chain customizations above since this should override any hardcoded --chain overrides.
-        owner = r.user if self._is_binary else c.SNAP_USER
         spec_dir = r.chain_spec_dir if self._is_binary else self._snap_config.get("chain_spec_dir")
         if self._chain_spec_url:
-            chain_spec_path = download_chain_spec(self._chain_spec_url, "chain-spec.json", spec_dir, owner)
+            chain_spec_path = spec_dir / "chain-spec.json"
             self.__set_chain_name(str(chain_spec_path), 0)
         if self._local_relaychain_spec_url:
-            relay_chain_spec_path = download_chain_spec(self._local_relaychain_spec_url, "relaychain-spec.json", spec_dir, owner)
+            relay_chain_spec_path = spec_dir / "relaychain-spec.json"
             self.__set_chain_name(str(relay_chain_spec_path), 1)
         if self._runtime_wasm_override:
             self.__add_firstchain_args(["--wasm-runtime-overrides", r.wasm_dir if self._is_binary else self._snap_config.get("wasm_dir")])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -3,7 +3,9 @@
 
 import sys
 import types
+from pathlib import Path
 from types import SimpleNamespace
+from unittest.mock import patch
 
 substrateinterface = types.ModuleType("substrateinterface")
 substrateinterface.SubstrateInterface = object
@@ -255,12 +257,35 @@ def test_prometheus_port():
         assert ServiceArgs(config, {}).prometheus_port == expected
 
 
+def test_service_args_with_chain_spec_url_does_not_download_chain_spec():
+    config = {
+        "service-args": "--chain polkadot --rpc-port 9933",
+        "data-dir": "",
+        "chain-spec-url": "https://example.invalid/chain-spec.json",
+        "local-relaychain-spec-url": "",
+        "wasm-runtime-url": "",
+        "docker-tag": "",
+        "binary-url": "",
+        "snap-name": "polkadot",
+    }
+
+    with patch("core.utils.download_util.download_chain_spec") as download_chain_spec:
+        service_args = ServiceArgs(config, {})
+
+    download_chain_spec.assert_not_called()
+    assert "--chain /var/snap/polkadot/common/spec/chain-spec.json" in service_args.service_args_string
+
+
 class _FakeWorkload:
     def __init__(self, running=True):
         self.running = running
         self.restart_calls = 0
         self.start_calls = 0
         self.set_service_args_calls = 0
+        self.configure_calls = 0
+        self.install_calls = 0
+        self.uninstall_calls = 0
+        self.stop_calls = 0
 
     def get_type(self):
         return WorkloadType.SNAP
@@ -282,6 +307,18 @@ class _FakeWorkload:
 
     def start_service(self):
         self.start_calls += 1
+
+    def stop_service(self):
+        self.stop_calls += 1
+
+    def configure(self, **kwargs):
+        self.configure_calls += 1
+
+    def install(self):
+        self.install_calls += 1
+
+    def uninstall(self):
+        self.uninstall_calls += 1
 
     def get_binary_version(self):
         return "1.0.0"
@@ -319,6 +356,12 @@ def _config_changed_charm(workload, stored):
         _has_valid_client_config=lambda: PolkadotCharm._has_valid_client_config(charm),
         _get_client_type=lambda: "snap",
         _get_workload_version=lambda: workload.get_binary_version(),
+    )
+    charm._chain_spec_download_context = lambda: PolkadotCharm._chain_spec_download_context(charm)
+    charm._download_configured_chain_specs = lambda chain_spec=True, local_relaychain_spec=True: PolkadotCharm._download_configured_chain_specs(
+        charm,
+        chain_spec=chain_spec,
+        local_relaychain_spec=local_relaychain_spec,
     )
     return charm
 
@@ -365,3 +408,40 @@ def test_config_changed_consumes_initial_start_pending_after_starting_workload()
     assert event.deferred is False
     assert workload.start_calls == 1
     assert stored.initial_start_pending is False
+
+
+def test_config_changed_downloads_chain_spec_when_url_changes():
+    workload = _FakeWorkload(running=True)
+    stored = _stored_state(initial_start_pending=False)
+    charm = _config_changed_charm(workload, stored)
+    charm.config["chain-spec-url"] = "https://example.invalid/chain-spec.json"
+    event = SimpleNamespace(deferred=False, defer=lambda: setattr(event, "deferred", True))
+
+    with patch("core.utils.download_util.download_chain_spec") as download_chain_spec:
+        PolkadotCharm._on_config_changed(charm, event)
+
+    download_chain_spec.assert_called_once_with(
+        "https://example.invalid/chain-spec.json",
+        "chain-spec.json",
+        Path("/var/snap/polkadot/common/spec"),
+        "root",
+    )
+    assert event.deferred is False
+    assert stored.chain_spec_url == "https://example.invalid/chain-spec.json"
+    assert workload.set_service_args_calls >= 1
+
+
+def test_config_changed_downloads_chain_spec_for_url_and_target_changes():
+    workload = _FakeWorkload(running=False)
+    stored = _stored_state(initial_start_pending=False)
+    stored.snap_name = "polkadot-parachain"
+    charm = _config_changed_charm(workload, stored)
+    charm.config["chain-spec-url"] = "https://example.invalid/chain-spec.json"
+    event = SimpleNamespace(deferred=False, defer=lambda: setattr(event, "deferred", True))
+
+    with patch("core.utils.download_util.download_chain_spec") as download_chain_spec:
+        PolkadotCharm._on_config_changed(charm, event)
+
+    assert download_chain_spec.call_count == 2
+    download_chain_spec.assert_any_call("https://example.invalid/chain-spec.json", "chain-spec.json", Path("/var/snap/polkadot/common/spec"), "root")
+    assert event.deferred is False


### PR DESCRIPTION
Before, it was downloading it on every update status hook, which is insane. A chain spec can be hundreds of megabyte.